### PR TITLE
Fix/remove-psyco

### DIFF
--- a/cellpack/autopack/octree.py
+++ b/cellpack/autopack/octree.py
@@ -29,6 +29,7 @@ DIRLOOKUP = {"3": 0, "2": 1, "-2": 2, "-1": 3, "1": 4, "0": 5, "-4": 6, "-3": 7}
 
 # End Globals ####
 
+
 class OctNode:
     # New Octnode Class, can be appended to as well i think
     def __init__(self, position, size, data):

--- a/cellpack/autopack/octree.py
+++ b/cellpack/autopack/octree.py
@@ -17,8 +17,6 @@
 # Then the cube has to subdivide itself, and arrange its objects in the new child nodes.
 # The new octNode itself contains no objects, but its children should.
 
-# Psyco may well speed this script up considerably, but results seem to vary.
-
 # TODO: Add support for multi-threading for node insertion and/or searching
 
 # Global Variables ####
@@ -30,16 +28,6 @@ MAX_OBJECTS_PER_CUBE = 10
 DIRLOOKUP = {"3": 0, "2": 1, "-2": 2, "-1": 3, "1": 4, "0": 5, "-4": 6, "-3": 7}
 
 # End Globals ####
-
-# Try importing psyco, in case it makes any speed difference
-# ( Speed increase seems to vary depending on system ).
-try:
-    import psyco
-
-    psyco.full()
-except Exception:
-    print("Could not import psyco, speed may suffer :)")
-
 
 class OctNode:
     # New Octnode Class, can be appended to as well i think


### PR DESCRIPTION
Problem
=======
removes unused import of psyco (unmaintained python library)

Solution
========
removed psyco imports

* Bug fix (non-breaking change which fixes an issue)

Keyfiles (delete if not relevant):
-----------------------

1. cellpack/autopack/octree.py
