### PR TITLE
suggested changes to PR

### DIFF
--- a/cellpack/autopack/interface_objects/ingredient_types.py
+++ b/cellpack/autopack/interface_objects/ingredient_types.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+
+class INGREDIENT_TYPE(Enum):
+    SINGLE_SPHERE = "single_sphere"
+    MULTI_SPHERE = "multi_sphere"
+    SINGLE_CUBE = "single_cube"
+    SINGLE_CYLINDER = "single_cylinder"
+    MULTI_CYLINDER = "multi_cylinder"
+    GROW = "grow"

--- a/cellpack/autopack/loaders/recipe_loader.py
+++ b/cellpack/autopack/loaders/recipe_loader.py
@@ -10,7 +10,7 @@ import cellpack.autopack as autopack
 from cellpack.autopack.loaders.util import create_file_info_object_from_full_path
 from cellpack.autopack.utils import deep_merge
 from .v1_v2_attribute_changes import (
-    ingredient_types,
+    ingredient_types_map,
     v1_to_v2_name_map,
     unused_attributes_list,
     convert_to_partners_map,
@@ -165,17 +165,10 @@ class RecipeLoader(object):
         new_ingredient = {}
         for attribute in list(old_ingredient):
             if attribute in v1_to_v2_name_map:
+                value = old_ingredient[attribute]
                 if attribute == "Type":
-                    converted_value = ingredient_types.convert(
-                        old_ingredient[attribute]
-                    )
-                    new_ingredient[
-                        v1_to_v2_name_map[attribute]
-                    ] = converted_value.get_key_name()
-                else:
-                    new_ingredient[v1_to_v2_name_map[attribute]] = old_ingredient[
-                        attribute
-                    ]
+                    value = ingredient_types_map[old_ingredient[attribute]]
+                new_ingredient[v1_to_v2_name_map[attribute]] = value
             elif attribute in unused_attributes_list:
                 del old_ingredient[attribute]
             elif attribute in convert_to_partners_map:

--- a/cellpack/autopack/loaders/recipe_loader.py
+++ b/cellpack/autopack/loaders/recipe_loader.py
@@ -165,8 +165,10 @@ class RecipeLoader(object):
         new_ingredient = {}
         for attribute in list(old_ingredient):
             if attribute in v1_to_v2_name_map:
-                value = old_ingredient[attribute]
                 if attribute == "Type":
+                    value = ingredient_types_map[old_ingredient[attribute]]
+                else: 
+                    value = old_ingredient[attribute]
                     value = ingredient_types_map[old_ingredient[attribute]]
                 new_ingredient[v1_to_v2_name_map[attribute]] = value
             elif attribute in unused_attributes_list:

--- a/cellpack/autopack/loaders/v1_v2_attribute_changes.py
+++ b/cellpack/autopack/loaders/v1_v2_attribute_changes.py
@@ -1,4 +1,4 @@
-from enum import Enum
+from cellpack.autopack.interface_objects.ingredient_types import INGREDIENT_TYPE
 
 v1_to_v2_name_map = {
     "Type": "type",
@@ -43,19 +43,11 @@ attributes_move_to_composition = [
     "priority",
 ]
 
-
-class ingredient_types(Enum):
-    SINGLE_SPHERE = "SingleSphere"
-    MULTI_SPHERE = "MultiSphere"
-    SINGLE_CUBE = "SingleCube"
-    SINGLE_CYLINDER = "SingleCylinder"
-    MULTI_CYLINDER = "MultiCylinder"
-    GROW = "Grow"
-
-    def convert(str):
-        for type_value in ingredient_types:
-            if str == type_value.value:
-                return type_value
-
-    def get_key_name(self):
-        return self.name.lower()
+ingredient_types_map = {
+    "SingleSphere": INGREDIENT_TYPE.SINGLE_SPHERE,
+    "MultiSphere": INGREDIENT_TYPE.MULTI_SPHERE,
+    "SingleCube": INGREDIENT_TYPE.SINGLE_CUBE,
+    "SingleCylinder": INGREDIENT_TYPE.SINGLE_CYLINDER,
+    "MultiCylinder": INGREDIENT_TYPE.MULTI_CYLINDER,
+    "Grow": INGREDIENT_TYPE.GROW,
+}

--- a/cellpack/tests/test_recipe_version_migration.py
+++ b/cellpack/tests/test_recipe_version_migration.py
@@ -3,6 +3,7 @@
 
 from math import pi
 import pytest
+from cellpack.autopack.interface_objects.ingredient_types import INGREDIENT_TYPE
 
 """
 Docs: https://docs.pytest.org/en/latest/example/simple.html
@@ -159,7 +160,7 @@ def test_create_packing_atomic_representation(
                 "orient_bias_range": [-pi, 12],
                 "representations": RecipeLoader.default_values["representations"],
                 "partners": {"probability_binding": 0.5},
-                "type": "multi_sphere",
+                "type": INGREDIENT_TYPE.MULTI_SPHERE,
             },
         ),
         (
@@ -173,7 +174,7 @@ def test_create_packing_atomic_representation(
                 "count": 15,
                 "orient_bias_range": [6, pi],
                 "representations": RecipeLoader.default_values["representations"],
-                "type": "grow",
+                "type": INGREDIENT_TYPE.GROW,
             },
         ),
         (
@@ -246,7 +247,7 @@ def test_get_v1_ingredient():
     region_list = []
     objects_dict = {}
     expected_object_data = {
-        "type": "single_sphere",
+        "type": INGREDIENT_TYPE.SINGLE_SPHERE,
         "representations": RecipeLoader.default_values["representations"],
         "orient_bias_range": [6, 12],
     }
@@ -269,7 +270,7 @@ def test_get_v1_ingredient():
             old_recipe_test_data,
             {
                 "A": {
-                    "type": "single_sphere",
+                    "type": INGREDIENT_TYPE.SINGLE_SPHERE,
                     "representations": RecipeLoader.default_values["representations"],
                     "orient_bias_range": [6, 12],
                 },
@@ -326,7 +327,7 @@ def test_convert_v1_to_v2(
                 "bounding_box": [[0, 0, 0], [1000, 1000, 1000]],
                 "objects": {
                     "A": {
-                        "type": "single_sphere",
+                        "type": INGREDIENT_TYPE.SINGLE_SPHERE,
                         "representations": RecipeLoader.default_values[
                             "representations"
                         ],


### PR DESCRIPTION
Sorry this this #76 issue didn't explain enums well, but this is more what I was thinking. 

You did a really good job with the explanation you were given. The point of the enum is to replace the string values with a constant. so the code can tell you if you have mistyped something. IE, if you type `if type == "sing_sphere"` the code doesn't know that nothing is ever going to be called `sing_sphere`. But `type == INGREDIENT_TYPE.SINGLE_SPHERE` can't be mistyped. 

We want this typing for the new schema, the old schema isn't going to change, so the simple mapping like we did before is sufficient, but we're just mapping to enum values instead of strings. 
