### PR TITLE
Feature/reorganize migration functions

### DIFF
--- a/cellpack/autopack/interface_objects/default_values.py
+++ b/cellpack/autopack/interface_objects/default_values.py
@@ -1,4 +1,3 @@
-
 default_recipe_values = {
     "bounding_box": [[0, 0, 0], [100, 100, 100]],
     "representations": {"atomic": None, "packing": None, "mesh": None},

--- a/cellpack/autopack/interface_objects/default_values.py
+++ b/cellpack/autopack/interface_objects/default_values.py
@@ -1,0 +1,5 @@
+
+default_recipe_values = {
+    "bounding_box": [[0, 0, 0], [100, 100, 100]],
+    "representations": {"atomic": None, "packing": None, "mesh": None},
+}

--- a/cellpack/autopack/loaders/migrate_v1_to_v2.py
+++ b/cellpack/autopack/loaders/migrate_v1_to_v2.py
@@ -9,7 +9,7 @@ from .v1_v2_attribute_changes import (
     v1_to_v2_name_map,
     attributes_move_to_composition,
     ingredient_types_map,
-    unused_attributes_list
+    unused_attributes_list,
 )
 
 

--- a/cellpack/autopack/loaders/migrate_v1_to_v2.py
+++ b/cellpack/autopack/loaders/migrate_v1_to_v2.py
@@ -1,45 +1,52 @@
 from math import pi
+
 from cellpack.autopack.interface_objects.ingredient_types import INGREDIENT_TYPE
 from cellpack.autopack.loaders.util import create_file_info_object_from_full_path
-from cellpack.autopack.loaders.recipe_loader import RecipeLoader
-from .v1_v2_attribute_changes import *
+from cellpack.autopack.interface_objects.default_values import default_recipe_values
+from .v1_v2_attribute_changes import (
+    convert_to_partners_map,
+    required_attributes,
+    v1_to_v2_name_map,
+    attributes_move_to_composition,
+    ingredient_types_map,
+    unused_attributes_list
+)
+
 
 def convert_to_representations(old_ingredient):
-        from cellpack.autopack.loaders.recipe_loader import RecipeLoader
-        representations = RecipeLoader.default_values["representations"].copy()
-        if "sphereFile" in old_ingredient and old_ingredient["sphereFile"] is not None:
-            representations["packing"] = create_file_info_object_from_full_path(
-                old_ingredient["sphereFile"]
-            )
-        if "meshFile" in old_ingredient and old_ingredient["meshFile"] is not None:
-            representations["mesh"] = create_file_info_object_from_full_path(
-                old_ingredient["meshFile"]
-            )
-            if (
-                "coordsystem" in old_ingredient
-                and old_ingredient["coordsystem"] is not None
-            ):
-                representations["mesh"]["coordinate_system"] = old_ingredient[
-                    "coordsystem"
-                ]
-        if "pdb" in old_ingredient and old_ingredient["pdb"] is not None:
-            if ".pdb" in old_ingredient["pdb"]:
-                representations["atomic"] = {
-                    "path": "default",
-                    "name": old_ingredient["pdb"],
-                    "format": ".pdb",
-                }
-            else:
-                representations["atomic"] = {
-                    "id": old_ingredient["pdb"],
-                    "format": ".pdb",
-                }
-            if "source" in old_ingredient and "transform" in old_ingredient["source"]:
-                representations["atomic"]["transform"] = old_ingredient["source"][
-                    "transform"
-                ]
+    representations = default_recipe_values["representations"].copy()
+    if "sphereFile" in old_ingredient and old_ingredient["sphereFile"] is not None:
+        representations["packing"] = create_file_info_object_from_full_path(
+            old_ingredient["sphereFile"]
+        )
+    if "meshFile" in old_ingredient and old_ingredient["meshFile"] is not None:
+        representations["mesh"] = create_file_info_object_from_full_path(
+            old_ingredient["meshFile"]
+        )
+        if (
+            "coordsystem" in old_ingredient
+            and old_ingredient["coordsystem"] is not None
+        ):
+            representations["mesh"]["coordinate_system"] = old_ingredient["coordsystem"]
+    if "pdb" in old_ingredient and old_ingredient["pdb"] is not None:
+        if ".pdb" in old_ingredient["pdb"]:
+            representations["atomic"] = {
+                "path": "default",
+                "name": old_ingredient["pdb"],
+                "format": ".pdb",
+            }
+        else:
+            representations["atomic"] = {
+                "id": old_ingredient["pdb"],
+                "format": ".pdb",
+            }
+        if "source" in old_ingredient and "transform" in old_ingredient["source"]:
+            representations["atomic"]["transform"] = old_ingredient["source"][
+                "transform"
+            ]
 
-        return representations
+    return representations
+
 
 def convert_rotation_range(old_ingredient):
     range_min = (
@@ -54,31 +61,29 @@ def convert_rotation_range(old_ingredient):
     )
     return [range_min, range_max]
 
+
 def migrate_ingredient(old_ingredient):
-        new_ingredient = {}
-        for attribute in list(old_ingredient):
-            if attribute in v1_to_v2_name_map:
-                if attribute == "Type":
-                    value = ingredient_types_map[old_ingredient[attribute]]
-                else:
-                    value = old_ingredient[attribute]
-                new_ingredient[v1_to_v2_name_map[attribute]] = value
-            elif attribute in unused_attributes_list:
-                del old_ingredient[attribute]
-            elif attribute in convert_to_partners_map:
-                if "partners" not in new_ingredient:
-                    partners = {}
-                    new_ingredient["partners"] = partners
-                partners[convert_to_partners_map[attribute]] = old_ingredient[attribute]
-        new_ingredient["orient_bias_range"] = convert_rotation_range(
-            old_ingredient
-        )
-        new_ingredient["representations"] = convert_to_representations(
-            old_ingredient
-        )
-        if new_ingredient["type"] == INGREDIENT_TYPE.SINGLE_SPHERE:
-            new_ingredient["radius"] = old_ingredient["radii"][0][0]
-        return new_ingredient
+    new_ingredient = {}
+    for attribute in list(old_ingredient):
+        if attribute in v1_to_v2_name_map:
+            if attribute == "Type":
+                value = ingredient_types_map[old_ingredient[attribute]]
+            else:
+                value = old_ingredient[attribute]
+            new_ingredient[v1_to_v2_name_map[attribute]] = value
+        elif attribute in unused_attributes_list:
+            del old_ingredient[attribute]
+        elif attribute in convert_to_partners_map:
+            if "partners" not in new_ingredient:
+                partners = {}
+                new_ingredient["partners"] = partners
+            partners[convert_to_partners_map[attribute]] = old_ingredient[attribute]
+    new_ingredient["orient_bias_range"] = convert_rotation_range(old_ingredient)
+    new_ingredient["representations"] = convert_to_representations(old_ingredient)
+    if new_ingredient["type"] == INGREDIENT_TYPE.SINGLE_SPHERE:
+        new_ingredient["radius"] = old_ingredient["radii"][0][0]
+    return new_ingredient
+
 
 def check_required_attributes(old_ingredient_data):
     if "Type" not in old_ingredient_data:
@@ -89,6 +94,7 @@ def check_required_attributes(old_ingredient_data):
         if attr not in old_ingredient_data:
             raise ValueError(f"{ingr_type} data needs {attr}")
 
+
 def split_ingredient_data(object_key, ingredient_data):
     composition_info = {"object": object_key}
     object_info = ingredient_data.copy()
@@ -98,26 +104,25 @@ def split_ingredient_data(object_key, ingredient_data):
             del object_info[attribute]
     return object_info, composition_info
 
+
 def get_v1_ingredient(ingredient_key, ingredient_data, region_list, objects_dict):
-        check_required_attributes(ingredient_data)
-        converted_ingredient = migrate_ingredient(ingredient_data)
-        object_info, composition_info = split_ingredient_data(
-            ingredient_key, converted_ingredient
-        )
-        region_list.append(composition_info)
-        objects_dict[ingredient_key] = object_info
+    check_required_attributes(ingredient_data)
+    converted_ingredient = migrate_ingredient(ingredient_data)
+    object_info, composition_info = split_ingredient_data(
+        ingredient_key, converted_ingredient
+    )
+    region_list.append(composition_info)
+    objects_dict[ingredient_key] = object_info
 
 
-def convert_v1_to_v2(recipe_data):
+def convert(recipe_data):
     objects_dict = {}
     composition = {"space": {"regions": {}}}
     if "cytoplasme" in recipe_data:
         outer_most_region_array = []
         composition["space"]["regions"]["interior"] = outer_most_region_array
         for ingredient_key in recipe_data["cytoplasme"]["ingredients"]:
-            ingredient_data = recipe_data["cytoplasme"]["ingredients"][
-                ingredient_key
-            ]
+            ingredient_data = recipe_data["cytoplasme"]["ingredients"][ingredient_key]
             get_v1_ingredient(
                 ingredient_key,
                 ingredient_data,
@@ -125,17 +130,3 @@ def convert_v1_to_v2(recipe_data):
                 objects_dict,
             )
     return objects_dict, composition
-
-def migrate_version(self,recipe, format_version="1.0"):
-        new_recipe = {}
-
-        if format_version == "1.0":
-            new_recipe["version"] = recipe["recipe"]["version"]
-            new_recipe["format_version"] = self.current_version
-            new_recipe["name"] = recipe["recipe"]["name"]
-            new_recipe["bounding_box"] = recipe["options"]["boundingBox"]
-            (
-                new_recipe["objects"],
-                new_recipe["composition"],
-            ) = convert_v1_to_v2(recipe)
-        return new_recipe

--- a/cellpack/autopack/loaders/migrate_v1_to_v2.py
+++ b/cellpack/autopack/loaders/migrate_v1_to_v2.py
@@ -1,0 +1,141 @@
+from math import pi
+from cellpack.autopack.interface_objects.ingredient_types import INGREDIENT_TYPE
+from cellpack.autopack.loaders.util import create_file_info_object_from_full_path
+from cellpack.autopack.loaders.recipe_loader import RecipeLoader
+from .v1_v2_attribute_changes import *
+
+def convert_to_representations(old_ingredient):
+        from cellpack.autopack.loaders.recipe_loader import RecipeLoader
+        representations = RecipeLoader.default_values["representations"].copy()
+        if "sphereFile" in old_ingredient and old_ingredient["sphereFile"] is not None:
+            representations["packing"] = create_file_info_object_from_full_path(
+                old_ingredient["sphereFile"]
+            )
+        if "meshFile" in old_ingredient and old_ingredient["meshFile"] is not None:
+            representations["mesh"] = create_file_info_object_from_full_path(
+                old_ingredient["meshFile"]
+            )
+            if (
+                "coordsystem" in old_ingredient
+                and old_ingredient["coordsystem"] is not None
+            ):
+                representations["mesh"]["coordinate_system"] = old_ingredient[
+                    "coordsystem"
+                ]
+        if "pdb" in old_ingredient and old_ingredient["pdb"] is not None:
+            if ".pdb" in old_ingredient["pdb"]:
+                representations["atomic"] = {
+                    "path": "default",
+                    "name": old_ingredient["pdb"],
+                    "format": ".pdb",
+                }
+            else:
+                representations["atomic"] = {
+                    "id": old_ingredient["pdb"],
+                    "format": ".pdb",
+                }
+            if "source" in old_ingredient and "transform" in old_ingredient["source"]:
+                representations["atomic"]["transform"] = old_ingredient["source"][
+                    "transform"
+                ]
+
+        return representations
+
+def convert_rotation_range(old_ingredient):
+    range_min = (
+        old_ingredient["orientBiasRotRangeMin"]
+        if "orientBiasRotRangeMin" in old_ingredient
+        else -pi
+    )
+    range_max = (
+        old_ingredient["orientBiasRotRangeMax"]
+        if "orientBiasRotRangeMax" in old_ingredient
+        else pi
+    )
+    return [range_min, range_max]
+
+def migrate_ingredient(old_ingredient):
+        new_ingredient = {}
+        for attribute in list(old_ingredient):
+            if attribute in v1_to_v2_name_map:
+                if attribute == "Type":
+                    value = ingredient_types_map[old_ingredient[attribute]]
+                else:
+                    value = old_ingredient[attribute]
+                new_ingredient[v1_to_v2_name_map[attribute]] = value
+            elif attribute in unused_attributes_list:
+                del old_ingredient[attribute]
+            elif attribute in convert_to_partners_map:
+                if "partners" not in new_ingredient:
+                    partners = {}
+                    new_ingredient["partners"] = partners
+                partners[convert_to_partners_map[attribute]] = old_ingredient[attribute]
+        new_ingredient["orient_bias_range"] = convert_rotation_range(
+            old_ingredient
+        )
+        new_ingredient["representations"] = convert_to_representations(
+            old_ingredient
+        )
+        if new_ingredient["type"] == INGREDIENT_TYPE.SINGLE_SPHERE:
+            new_ingredient["radius"] = old_ingredient["radii"][0][0]
+        return new_ingredient
+
+def check_required_attributes(old_ingredient_data):
+    if "Type" not in old_ingredient_data:
+        old_ingredient_data["Type"] = "SingleSphere"
+    ingr_type = old_ingredient_data["Type"]
+    required = required_attributes[ingr_type]
+    for attr in required:
+        if attr not in old_ingredient_data:
+            raise ValueError(f"{ingr_type} data needs {attr}")
+
+def split_ingredient_data(object_key, ingredient_data):
+    composition_info = {"object": object_key}
+    object_info = ingredient_data.copy()
+    for attribute in attributes_move_to_composition:
+        if attribute in ingredient_data:
+            composition_info[attribute] = ingredient_data[attribute]
+            del object_info[attribute]
+    return object_info, composition_info
+
+def get_v1_ingredient(ingredient_key, ingredient_data, region_list, objects_dict):
+        check_required_attributes(ingredient_data)
+        converted_ingredient = migrate_ingredient(ingredient_data)
+        object_info, composition_info = split_ingredient_data(
+            ingredient_key, converted_ingredient
+        )
+        region_list.append(composition_info)
+        objects_dict[ingredient_key] = object_info
+
+
+def convert_v1_to_v2(recipe_data):
+    objects_dict = {}
+    composition = {"space": {"regions": {}}}
+    if "cytoplasme" in recipe_data:
+        outer_most_region_array = []
+        composition["space"]["regions"]["interior"] = outer_most_region_array
+        for ingredient_key in recipe_data["cytoplasme"]["ingredients"]:
+            ingredient_data = recipe_data["cytoplasme"]["ingredients"][
+                ingredient_key
+            ]
+            get_v1_ingredient(
+                ingredient_key,
+                ingredient_data,
+                outer_most_region_array,
+                objects_dict,
+            )
+    return objects_dict, composition
+
+def migrate_version(self,recipe, format_version="1.0"):
+        new_recipe = {}
+
+        if format_version == "1.0":
+            new_recipe["version"] = recipe["recipe"]["version"]
+            new_recipe["format_version"] = self.current_version
+            new_recipe["name"] = recipe["recipe"]["name"]
+            new_recipe["bounding_box"] = recipe["options"]["boundingBox"]
+            (
+                new_recipe["objects"],
+                new_recipe["composition"],
+            ) = convert_v1_to_v2(recipe)
+        return new_recipe

--- a/cellpack/autopack/loaders/recipe_loader.py
+++ b/cellpack/autopack/loaders/recipe_loader.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import copy
-from math import pi
 import os
 
 import json
@@ -9,6 +8,8 @@ from json import encoder
 import cellpack.autopack as autopack
 from cellpack.autopack.utils import deep_merge
 from cellpack.autopack.interface_objects.representations import Representations
+from cellpack.autopack.interface_objects.default_values import default_recipe_values
+from cellpack.autopack.loaders.migrate_v1_to_v2 import convert
 
 encoder.FLOAT_REPR = lambda o: format(o, ".8g")
 CURRENT_VERSION = "2.0"
@@ -16,10 +17,7 @@ CURRENT_VERSION = "2.0"
 
 class RecipeLoader(object):
     # TODO: add all default values here
-    default_values = {
-        "bounding_box": [[0, 0, 0], [100, 100, 100]],
-        "representations": {"atomic": None, "packing": None, "mesh": None},
-    }
+    default_values = default_recipe_values.copy()
 
     def __init__(self, input_file_path):
         _, file_extension = os.path.splitext(input_file_path)
@@ -118,151 +116,22 @@ class RecipeLoader(object):
             return None
         return data
 
-    # @staticmethod
-    # def _convert_to_representations(old_ingredient):
-    #     representations = RecipeLoader.default_values["representations"].copy()
-    #     if "sphereFile" in old_ingredient and old_ingredient["sphereFile"] is not None:
-    #         representations["packing"] = create_file_info_object_from_full_path(
-    #             old_ingredient["sphereFile"]
-    #         )
-    #     if "meshFile" in old_ingredient and old_ingredient["meshFile"] is not None:
-    #         representations["mesh"] = create_file_info_object_from_full_path(
-    #             old_ingredient["meshFile"]
-    #         )
-    #         if (
-    #             "coordsystem" in old_ingredient
-    #             and old_ingredient["coordsystem"] is not None
-    #         ):
-    #             representations["mesh"]["coordinate_system"] = old_ingredient[
-    #                 "coordsystem"
-    #             ]
-    #     if "pdb" in old_ingredient and old_ingredient["pdb"] is not None:
-    #         if ".pdb" in old_ingredient["pdb"]:
-    #             representations["atomic"] = {
-    #                 "path": "default",
-    #                 "name": old_ingredient["pdb"],
-    #                 "format": ".pdb",
-    #             }
-    #         else:
-    #             representations["atomic"] = {
-    #                 "id": old_ingredient["pdb"],
-    #                 "format": ".pdb",
-    #             }
-    #         if "source" in old_ingredient and "transform" in old_ingredient["source"]:
-    #             representations["atomic"]["transform"] = old_ingredient["source"][
-    #                 "transform"
-    #             ]
+    def _migrate_version(self, recipe, format_version="1.0"):
+        new_recipe = {}
 
-    #     return representations
+        if format_version == "1.0":
 
-    # @staticmethod
-    # def _convert_rotation_range(old_ingredient):
-    #     range_min = (
-    #         old_ingredient["orientBiasRotRangeMin"]
-    #         if "orientBiasRotRangeMin" in old_ingredient
-    #         else -pi
-    #     )
-    #     range_max = (
-    #         old_ingredient["orientBiasRotRangeMax"]
-    #         if "orientBiasRotRangeMax" in old_ingredient
-    #         else pi
-    #     )
-    #     return [range_min, range_max]
-
-    # @staticmethod
-    # def _migrate_ingredient(old_ingredient):
-    #     new_ingredient = {}
-    #     for attribute in list(old_ingredient):
-    #         if attribute in v1_to_v2_name_map:
-    #             if attribute == "Type":
-    #                 value = ingredient_types_map[old_ingredient[attribute]]
-    #             else:
-    #                 value = old_ingredient[attribute]
-    #             new_ingredient[v1_to_v2_name_map[attribute]] = value
-    #         elif attribute in unused_attributes_list:
-    #             del old_ingredient[attribute]
-    #         elif attribute in convert_to_partners_map:
-    #             if "partners" not in new_ingredient:
-    #                 partners = {}
-    #                 new_ingredient["partners"] = partners
-    #             partners[convert_to_partners_map[attribute]] = old_ingredient[attribute]
-    #     new_ingredient["orient_bias_range"] = RecipeLoader._convert_rotation_range(
-    #         old_ingredient
-    #     )
-    #     new_ingredient["representations"] = RecipeLoader._convert_to_representations(
-    #         old_ingredient
-    #     )
-    #     if new_ingredient["type"] == INGREDIENT_TYPE.SINGLE_SPHERE:
-    #         new_ingredient["radius"] = old_ingredient["radii"][0][0]
-    #     return new_ingredient
-
-    # @staticmethod
-    # def _check_required_attributes(old_ingredient_data):
-    #     if "Type" not in old_ingredient_data:
-    #         old_ingredient_data["Type"] = "SingleSphere"
-    #     ingr_type = old_ingredient_data["Type"]
-    #     required = required_attributes[ingr_type]
-    #     for attr in required:
-    #         if attr not in old_ingredient_data:
-    #             raise ValueError(f"{ingr_type} data needs {attr}")
-
-    # @staticmethod
-    # def _split_ingredient_data(object_key, ingredient_data):
-    #     composition_info = {"object": object_key}
-    #     object_info = ingredient_data.copy()
-    #     for attribute in attributes_move_to_composition:
-    #         if attribute in ingredient_data:
-    #             composition_info[attribute] = ingredient_data[attribute]
-    #             del object_info[attribute]
-    #     return object_info, composition_info
-
-    # @staticmethod
-    # def _get_v1_ingredient(ingredient_key, ingredient_data, region_list, objects_dict):
-    #     RecipeLoader._check_required_attributes(ingredient_data)
-    #     converted_ingredient = RecipeLoader._migrate_ingredient(ingredient_data)
-    #     object_info, composition_info = RecipeLoader._split_ingredient_data(
-    #         ingredient_key, converted_ingredient
-    #     )
-    #     region_list.append(composition_info)
-    #     objects_dict[ingredient_key] = object_info
-
-    # @staticmethod
-    # def _convert_v1_to_v2(recipe_data):
-    #     objects_dict = {}
-    #     composition = {"space": {"regions": {}}}
-    #     if "cytoplasme" in recipe_data:
-    #         outer_most_region_array = []
-    #         composition["space"]["regions"]["interior"] = outer_most_region_array
-    #         for ingredient_key in recipe_data["cytoplasme"]["ingredients"]:
-    #             ingredient_data = recipe_data["cytoplasme"]["ingredients"][
-    #                 ingredient_key
-    #             ]
-    #             RecipeLoader._get_v1_ingredient(
-    #                 ingredient_key,
-    #                 ingredient_data,
-    #                 outer_most_region_array,
-    #                 objects_dict,
-    #             )
-    #     return objects_dict, composition
-
-    # def _migrate_version(self, recipe, format_version="1.0"):
-    #     new_recipe = {}
-
-    #     if format_version == "1.0":
-
-    #         new_recipe["version"] = recipe["recipe"]["version"]
-    #         new_recipe["format_version"] = self.current_version
-    #         new_recipe["name"] = recipe["recipe"]["name"]
-    #         new_recipe["bounding_box"] = recipe["options"]["boundingBox"]
-    #         (
-    #             new_recipe["objects"],
-    #             new_recipe["composition"],
-    #         ) = RecipeLoader._convert_v1_to_v2(recipe)
-    #     return new_recipe
-
+            new_recipe["version"] = recipe["recipe"]["version"]
+            new_recipe["format_version"] = self.current_version
+            new_recipe["name"] = recipe["recipe"]["name"]
+            new_recipe["bounding_box"] = recipe["options"]["boundingBox"]
+            (
+                new_recipe["objects"],
+                new_recipe["composition"],
+            ) = convert(recipe)
+        return new_recipe
 
     def _read(self):
-        from cellpack.autopack.loaders.migrate_v1_to_v2 import migrate_version
         new_values = json.load(open(self.file_path, "r"))
         recipe_data = RecipeLoader.default_values.copy()
         recipe_data = deep_merge(recipe_data, new_values)
@@ -275,7 +144,7 @@ class RecipeLoader(object):
                 if "format_version" in recipe_data
                 else "1.0"
             )
-            recipe_data = migrate_version(recipe_data, input_format_version)
+            recipe_data = self._migrate_version(recipe_data, input_format_version)
 
         # TODO: request any external data before returning
         if "objects" in recipe_data:

--- a/cellpack/autopack/loaders/recipe_loader.py
+++ b/cellpack/autopack/loaders/recipe_loader.py
@@ -7,17 +7,7 @@ import json
 from json import encoder
 
 import cellpack.autopack as autopack
-from cellpack.autopack.interface_objects.ingredient_types import INGREDIENT_TYPE
-from cellpack.autopack.loaders.util import create_file_info_object_from_full_path
 from cellpack.autopack.utils import deep_merge
-from .v1_v2_attribute_changes import (
-    ingredient_types_map,
-    v1_to_v2_name_map,
-    unused_attributes_list,
-    convert_to_partners_map,
-    attributes_move_to_composition,
-    required_attributes,
-)
 from cellpack.autopack.interface_objects.representations import Representations
 
 encoder.FLOAT_REPR = lambda o: format(o, ".8g")
@@ -128,149 +118,151 @@ class RecipeLoader(object):
             return None
         return data
 
-    @staticmethod
-    def _convert_to_representations(old_ingredient):
-        representations = RecipeLoader.default_values["representations"].copy()
-        if "sphereFile" in old_ingredient and old_ingredient["sphereFile"] is not None:
-            representations["packing"] = create_file_info_object_from_full_path(
-                old_ingredient["sphereFile"]
-            )
-        if "meshFile" in old_ingredient and old_ingredient["meshFile"] is not None:
-            representations["mesh"] = create_file_info_object_from_full_path(
-                old_ingredient["meshFile"]
-            )
-            if (
-                "coordsystem" in old_ingredient
-                and old_ingredient["coordsystem"] is not None
-            ):
-                representations["mesh"]["coordinate_system"] = old_ingredient[
-                    "coordsystem"
-                ]
-        if "pdb" in old_ingredient and old_ingredient["pdb"] is not None:
-            if ".pdb" in old_ingredient["pdb"]:
-                representations["atomic"] = {
-                    "path": "default",
-                    "name": old_ingredient["pdb"],
-                    "format": ".pdb",
-                }
-            else:
-                representations["atomic"] = {
-                    "id": old_ingredient["pdb"],
-                    "format": ".pdb",
-                }
-            if "source" in old_ingredient and "transform" in old_ingredient["source"]:
-                representations["atomic"]["transform"] = old_ingredient["source"][
-                    "transform"
-                ]
+    # @staticmethod
+    # def _convert_to_representations(old_ingredient):
+    #     representations = RecipeLoader.default_values["representations"].copy()
+    #     if "sphereFile" in old_ingredient and old_ingredient["sphereFile"] is not None:
+    #         representations["packing"] = create_file_info_object_from_full_path(
+    #             old_ingredient["sphereFile"]
+    #         )
+    #     if "meshFile" in old_ingredient and old_ingredient["meshFile"] is not None:
+    #         representations["mesh"] = create_file_info_object_from_full_path(
+    #             old_ingredient["meshFile"]
+    #         )
+    #         if (
+    #             "coordsystem" in old_ingredient
+    #             and old_ingredient["coordsystem"] is not None
+    #         ):
+    #             representations["mesh"]["coordinate_system"] = old_ingredient[
+    #                 "coordsystem"
+    #             ]
+    #     if "pdb" in old_ingredient and old_ingredient["pdb"] is not None:
+    #         if ".pdb" in old_ingredient["pdb"]:
+    #             representations["atomic"] = {
+    #                 "path": "default",
+    #                 "name": old_ingredient["pdb"],
+    #                 "format": ".pdb",
+    #             }
+    #         else:
+    #             representations["atomic"] = {
+    #                 "id": old_ingredient["pdb"],
+    #                 "format": ".pdb",
+    #             }
+    #         if "source" in old_ingredient and "transform" in old_ingredient["source"]:
+    #             representations["atomic"]["transform"] = old_ingredient["source"][
+    #                 "transform"
+    #             ]
 
-        return representations
+    #     return representations
 
-    @staticmethod
-    def _convert_rotation_range(old_ingredient):
-        range_min = (
-            old_ingredient["orientBiasRotRangeMin"]
-            if "orientBiasRotRangeMin" in old_ingredient
-            else -pi
-        )
-        range_max = (
-            old_ingredient["orientBiasRotRangeMax"]
-            if "orientBiasRotRangeMax" in old_ingredient
-            else pi
-        )
-        return [range_min, range_max]
+    # @staticmethod
+    # def _convert_rotation_range(old_ingredient):
+    #     range_min = (
+    #         old_ingredient["orientBiasRotRangeMin"]
+    #         if "orientBiasRotRangeMin" in old_ingredient
+    #         else -pi
+    #     )
+    #     range_max = (
+    #         old_ingredient["orientBiasRotRangeMax"]
+    #         if "orientBiasRotRangeMax" in old_ingredient
+    #         else pi
+    #     )
+    #     return [range_min, range_max]
 
-    @staticmethod
-    def _migrate_ingredient(old_ingredient):
-        new_ingredient = {}
-        for attribute in list(old_ingredient):
-            if attribute in v1_to_v2_name_map:
-                if attribute == "Type":
-                    value = ingredient_types_map[old_ingredient[attribute]]
-                else:
-                    value = old_ingredient[attribute]
-                new_ingredient[v1_to_v2_name_map[attribute]] = value
-            elif attribute in unused_attributes_list:
-                del old_ingredient[attribute]
-            elif attribute in convert_to_partners_map:
-                if "partners" not in new_ingredient:
-                    partners = {}
-                    new_ingredient["partners"] = partners
-                partners[convert_to_partners_map[attribute]] = old_ingredient[attribute]
-        new_ingredient["orient_bias_range"] = RecipeLoader._convert_rotation_range(
-            old_ingredient
-        )
-        new_ingredient["representations"] = RecipeLoader._convert_to_representations(
-            old_ingredient
-        )
-        if new_ingredient["type"] == INGREDIENT_TYPE.SINGLE_SPHERE:
-            new_ingredient["radius"] = old_ingredient["radii"][0][0]
-        return new_ingredient
+    # @staticmethod
+    # def _migrate_ingredient(old_ingredient):
+    #     new_ingredient = {}
+    #     for attribute in list(old_ingredient):
+    #         if attribute in v1_to_v2_name_map:
+    #             if attribute == "Type":
+    #                 value = ingredient_types_map[old_ingredient[attribute]]
+    #             else:
+    #                 value = old_ingredient[attribute]
+    #             new_ingredient[v1_to_v2_name_map[attribute]] = value
+    #         elif attribute in unused_attributes_list:
+    #             del old_ingredient[attribute]
+    #         elif attribute in convert_to_partners_map:
+    #             if "partners" not in new_ingredient:
+    #                 partners = {}
+    #                 new_ingredient["partners"] = partners
+    #             partners[convert_to_partners_map[attribute]] = old_ingredient[attribute]
+    #     new_ingredient["orient_bias_range"] = RecipeLoader._convert_rotation_range(
+    #         old_ingredient
+    #     )
+    #     new_ingredient["representations"] = RecipeLoader._convert_to_representations(
+    #         old_ingredient
+    #     )
+    #     if new_ingredient["type"] == INGREDIENT_TYPE.SINGLE_SPHERE:
+    #         new_ingredient["radius"] = old_ingredient["radii"][0][0]
+    #     return new_ingredient
 
-    @staticmethod
-    def _check_required_attributes(old_ingredient_data):
-        if "Type" not in old_ingredient_data:
-            old_ingredient_data["Type"] = "SingleSphere"
-        ingr_type = old_ingredient_data["Type"]
-        required = required_attributes[ingr_type]
-        for attr in required:
-            if attr not in old_ingredient_data:
-                raise ValueError(f"{ingr_type} data needs {attr}")
+    # @staticmethod
+    # def _check_required_attributes(old_ingredient_data):
+    #     if "Type" not in old_ingredient_data:
+    #         old_ingredient_data["Type"] = "SingleSphere"
+    #     ingr_type = old_ingredient_data["Type"]
+    #     required = required_attributes[ingr_type]
+    #     for attr in required:
+    #         if attr not in old_ingredient_data:
+    #             raise ValueError(f"{ingr_type} data needs {attr}")
 
-    @staticmethod
-    def _split_ingredient_data(object_key, ingredient_data):
-        composition_info = {"object": object_key}
-        object_info = ingredient_data.copy()
-        for attribute in attributes_move_to_composition:
-            if attribute in ingredient_data:
-                composition_info[attribute] = ingredient_data[attribute]
-                del object_info[attribute]
-        return object_info, composition_info
+    # @staticmethod
+    # def _split_ingredient_data(object_key, ingredient_data):
+    #     composition_info = {"object": object_key}
+    #     object_info = ingredient_data.copy()
+    #     for attribute in attributes_move_to_composition:
+    #         if attribute in ingredient_data:
+    #             composition_info[attribute] = ingredient_data[attribute]
+    #             del object_info[attribute]
+    #     return object_info, composition_info
 
-    @staticmethod
-    def _get_v1_ingredient(ingredient_key, ingredient_data, region_list, objects_dict):
-        RecipeLoader._check_required_attributes(ingredient_data)
-        converted_ingredient = RecipeLoader._migrate_ingredient(ingredient_data)
-        object_info, composition_info = RecipeLoader._split_ingredient_data(
-            ingredient_key, converted_ingredient
-        )
-        region_list.append(composition_info)
-        objects_dict[ingredient_key] = object_info
+    # @staticmethod
+    # def _get_v1_ingredient(ingredient_key, ingredient_data, region_list, objects_dict):
+    #     RecipeLoader._check_required_attributes(ingredient_data)
+    #     converted_ingredient = RecipeLoader._migrate_ingredient(ingredient_data)
+    #     object_info, composition_info = RecipeLoader._split_ingredient_data(
+    #         ingredient_key, converted_ingredient
+    #     )
+    #     region_list.append(composition_info)
+    #     objects_dict[ingredient_key] = object_info
 
-    @staticmethod
-    def _convert_v1_to_v2(recipe_data):
-        objects_dict = {}
-        composition = {"space": {"regions": {}}}
-        if "cytoplasme" in recipe_data:
-            outer_most_region_array = []
-            composition["space"]["regions"]["interior"] = outer_most_region_array
-            for ingredient_key in recipe_data["cytoplasme"]["ingredients"]:
-                ingredient_data = recipe_data["cytoplasme"]["ingredients"][
-                    ingredient_key
-                ]
-                RecipeLoader._get_v1_ingredient(
-                    ingredient_key,
-                    ingredient_data,
-                    outer_most_region_array,
-                    objects_dict,
-                )
-        return objects_dict, composition
+    # @staticmethod
+    # def _convert_v1_to_v2(recipe_data):
+    #     objects_dict = {}
+    #     composition = {"space": {"regions": {}}}
+    #     if "cytoplasme" in recipe_data:
+    #         outer_most_region_array = []
+    #         composition["space"]["regions"]["interior"] = outer_most_region_array
+    #         for ingredient_key in recipe_data["cytoplasme"]["ingredients"]:
+    #             ingredient_data = recipe_data["cytoplasme"]["ingredients"][
+    #                 ingredient_key
+    #             ]
+    #             RecipeLoader._get_v1_ingredient(
+    #                 ingredient_key,
+    #                 ingredient_data,
+    #                 outer_most_region_array,
+    #                 objects_dict,
+    #             )
+    #     return objects_dict, composition
 
-    def _migrate_version(self, recipe, format_version="1.0"):
-        new_recipe = {}
+    # def _migrate_version(self, recipe, format_version="1.0"):
+    #     new_recipe = {}
 
-        if format_version == "1.0":
+    #     if format_version == "1.0":
 
-            new_recipe["version"] = recipe["recipe"]["version"]
-            new_recipe["format_version"] = self.current_version
-            new_recipe["name"] = recipe["recipe"]["name"]
-            new_recipe["bounding_box"] = recipe["options"]["boundingBox"]
-            (
-                new_recipe["objects"],
-                new_recipe["composition"],
-            ) = RecipeLoader._convert_v1_to_v2(recipe)
-        return new_recipe
+    #         new_recipe["version"] = recipe["recipe"]["version"]
+    #         new_recipe["format_version"] = self.current_version
+    #         new_recipe["name"] = recipe["recipe"]["name"]
+    #         new_recipe["bounding_box"] = recipe["options"]["boundingBox"]
+    #         (
+    #             new_recipe["objects"],
+    #             new_recipe["composition"],
+    #         ) = RecipeLoader._convert_v1_to_v2(recipe)
+    #     return new_recipe
+
 
     def _read(self):
+        from cellpack.autopack.loaders.migrate_v1_to_v2 import migrate_version
         new_values = json.load(open(self.file_path, "r"))
         recipe_data = RecipeLoader.default_values.copy()
         recipe_data = deep_merge(recipe_data, new_values)
@@ -283,7 +275,7 @@ class RecipeLoader(object):
                 if "format_version" in recipe_data
                 else "1.0"
             )
-            recipe_data = self._migrate_version(recipe_data, input_format_version)
+            recipe_data = migrate_version(recipe_data, input_format_version)
 
         # TODO: request any external data before returning
         if "objects" in recipe_data:

--- a/cellpack/tests/test_recipe_version_migration.py
+++ b/cellpack/tests/test_recipe_version_migration.py
@@ -325,7 +325,7 @@ def test_get_v1_ingredient():
 def test_convert_v1_to_v2(
     old_recipe_test_data, expected_object_dict, expected_composition_dict
 ):
-    objects_dict, composition = convert_v1_to_v2(old_recipe_test_data)
+    objects_dict, composition = convert(old_recipe_test_data)
     assert objects_dict == expected_object_dict
     assert composition == expected_composition_dict
 

--- a/cellpack/tests/test_recipe_version_migration.py
+++ b/cellpack/tests/test_recipe_version_migration.py
@@ -11,6 +11,8 @@ import pytest
 from cellpack.autopack.interface_objects.representations import Representations
 from cellpack.autopack.interface_objects.ingredient_types import INGREDIENT_TYPE
 from cellpack.autopack.loaders.recipe_loader import RecipeLoader
+from cellpack.autopack.loaders.migrate_v1_to_v2 import *
+
 
 
 @pytest.mark.parametrize(
@@ -55,7 +57,7 @@ from cellpack.autopack.loaders.recipe_loader import RecipeLoader
     ],
 )
 def test_create_packing_sphere_representation(sphereFile_data, sphereFile_result):
-    assert sphereFile_result == RecipeLoader._convert_to_representations(
+    assert sphereFile_result == convert_to_representations(
         sphereFile_data
     )
 
@@ -100,7 +102,7 @@ def test_create_packing_mesh_representation(
     mesh_data,
     mesh_result,
 ):
-    assert mesh_result == RecipeLoader._convert_to_representations(mesh_data)
+    assert mesh_result == convert_to_representations(mesh_data)
 
 
 @pytest.mark.parametrize(
@@ -139,7 +141,7 @@ def test_create_packing_atomic_representation(
     atomic_test_data,
     expected_atomic_result,
 ):
-    assert expected_atomic_result == RecipeLoader._convert_to_representations(
+    assert expected_atomic_result == convert_to_representations(
         atomic_test_data
     )
 
@@ -202,7 +204,7 @@ def test_migrate_ingredient(
     old_ingredient,
     expected_result,
 ):
-    assert expected_result == RecipeLoader._migrate_ingredient(old_ingredient)
+    assert expected_result == migrate_ingredient(old_ingredient)
     assert "encapsulatingRadius" not in expected_result
 
 
@@ -263,7 +265,7 @@ def test_get_v1_ingredient():
         "object": ingredient_key,
         "count": 15,
     }
-    RecipeLoader._get_v1_ingredient(
+    get_v1_ingredient(
         ingredient_key, ingredient_data, region_list, objects_dict
     )
     assert len(region_list) == 1
@@ -323,7 +325,7 @@ def test_get_v1_ingredient():
 def test_convert_v1_to_v2(
     old_recipe_test_data, expected_object_dict, expected_composition_dict
 ):
-    objects_dict, composition = RecipeLoader._convert_v1_to_v2(old_recipe_test_data)
+    objects_dict, composition = convert_v1_to_v2(old_recipe_test_data)
     assert objects_dict == expected_object_dict
     assert composition == expected_composition_dict
 

--- a/cellpack/tests/test_recipe_version_migration.py
+++ b/cellpack/tests/test_recipe_version_migration.py
@@ -11,8 +11,12 @@ import pytest
 from cellpack.autopack.interface_objects.representations import Representations
 from cellpack.autopack.interface_objects.ingredient_types import INGREDIENT_TYPE
 from cellpack.autopack.loaders.recipe_loader import RecipeLoader
-from cellpack.autopack.loaders.migrate_v1_to_v2 import *
-
+from cellpack.autopack.loaders.migrate_v1_to_v2 import (
+    convert,
+    convert_to_representations,
+    migrate_ingredient,
+    get_v1_ingredient,
+)
 
 
 @pytest.mark.parametrize(
@@ -57,9 +61,7 @@ from cellpack.autopack.loaders.migrate_v1_to_v2 import *
     ],
 )
 def test_create_packing_sphere_representation(sphereFile_data, sphereFile_result):
-    assert sphereFile_result == convert_to_representations(
-        sphereFile_data
-    )
+    assert sphereFile_result == convert_to_representations(sphereFile_data)
 
 
 @pytest.mark.parametrize(
@@ -141,9 +143,7 @@ def test_create_packing_atomic_representation(
     atomic_test_data,
     expected_atomic_result,
 ):
-    assert expected_atomic_result == convert_to_representations(
-        atomic_test_data
-    )
+    assert expected_atomic_result == convert_to_representations(atomic_test_data)
 
 
 @pytest.mark.parametrize(
@@ -265,9 +265,7 @@ def test_get_v1_ingredient():
         "object": ingredient_key,
         "count": 15,
     }
-    get_v1_ingredient(
-        ingredient_key, ingredient_data, region_list, objects_dict
-    )
+    get_v1_ingredient(ingredient_key, ingredient_data, region_list, objects_dict)
     assert len(region_list) == 1
     assert objects_dict[ingredient_key] == expected_object_data
     assert region_list[0] == expected_composition_data


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
closes #83 

Solution
========
What I/we did to solve this problem

- Moved functions for migration from `recipe_loader` to the newly created file cellpack/autopack/loaders/migrate_v1_to_v2.py
- Moved default values from `recipe_loader` to a new file to avoid import errors  

with @meganrm 

## Type of change
Please delete options that are not relevant.

* Code refactoring (non-breaking change which refactors the code)