### PR TITLE
make sure there are not mistakes in format versions

### DIFF
--- a/cellpack/autopack/loaders/recipe_loader.py
+++ b/cellpack/autopack/loaders/recipe_loader.py
@@ -115,11 +115,11 @@ class RecipeLoader(object):
             print("filename is None and not ingredient dictionary provided")
             return None
         return data
-    
+
     @staticmethod
     def _sanitize_format_version(recipe_data):
         if "format_version" not in recipe_data:
-            format_version = "1.0" # all recipes before we introduced versioning
+            format_version = "1.0"  # all recipes before we introduced versioning
         elif len(recipe_data["format_version"].split(".")) > 2:
             # We only use two places for format version, but people
             # might accidently include a third number
@@ -143,15 +143,19 @@ class RecipeLoader(object):
                 new_recipe["objects"],
                 new_recipe["composition"],
             ) = convert(recipe)
-        else: 
-            raise ValueError(f"{recipe['format_version']} is not a format vesion we support")
+        else:
+            raise ValueError(
+                f"{recipe['format_version']} is not a format vesion we support"
+            )
         return new_recipe
 
     def _read(self):
         new_values = json.load(open(self.file_path, "r"))
         recipe_data = RecipeLoader.default_values.copy()
         recipe_data = deep_merge(recipe_data, new_values)
-        recipe_data["format_version"] = RecipeLoader._sanitize_format_version(recipe_data)
+        recipe_data["format_version"] = RecipeLoader._sanitize_format_version(
+            recipe_data
+        )
 
         if recipe_data["format_version"] != self.current_version:
             recipe_data = self._migrate_version(recipe_data)

--- a/cellpack/autopack/loaders/recipe_loader.py
+++ b/cellpack/autopack/loaders/recipe_loader.py
@@ -143,6 +143,8 @@ class RecipeLoader(object):
                 new_recipe["objects"],
                 new_recipe["composition"],
             ) = convert(recipe)
+        else: 
+            raise ValueError(f"{recipe['format_version']} is not a format vesion we support")
         return new_recipe
 
     def _read(self):

--- a/cellpack/autopack/loaders/recipe_loader.py
+++ b/cellpack/autopack/loaders/recipe_loader.py
@@ -125,7 +125,13 @@ class RecipeLoader(object):
             # might accidently include a third number
             # ie 2.0.0 instead of 2.0
             split_numbers = recipe_data["format_version"].split(".")
-            format_version = ".".join([split_numbers[0], split_numbers[1]])
+            format_version = f"{split_numbers[0]}.{split_numbers[1]}"
+        elif len(recipe_data["format_version"].split(".")) == 1:
+            # We only use two places for format version, but people
+            # might accidently include a third number
+            # ie 2.0.0 instead of 2.0
+            split_numbers = recipe_data["format_version"].split(".")
+            format_version = f"{split_numbers[0]}.0"
         else:
             format_version = recipe_data["format_version"]
         return format_version

--- a/cellpack/tests/test_recipe_loader.py
+++ b/cellpack/tests/test_recipe_loader.py
@@ -92,6 +92,14 @@ def test_resolve_objects():
             {"format_version": "2.105"},
             "2.105",
         ),
+        (
+            {"format_version": "2"},
+            "2.0",
+        ),
+        (
+            {"format_version": "1"},
+            "1.0",
+        ),
     ],
 )
 def test_sanitize_format_version(expected_result, input_recipe_data):

--- a/cellpack/tests/test_recipe_loader.py
+++ b/cellpack/tests/test_recipe_loader.py
@@ -4,7 +4,7 @@
 Docs: https://docs.pytest.org/en/latest/example/simple.html
     https://docs.pytest.org/en/latest/plugins.html#requiring-loading-plugins-in-a-test-module-or-conftest-file
 """
-
+import pytest
 from cellpack.autopack.loaders.recipe_loader import RecipeLoader
 
 test_objects = {
@@ -67,3 +67,33 @@ def test_resolve_objects():
     # assert resolved_objects["sphere_50"]["radius"] == 50
     # TODO: add granular testing for individual objects
     assert resolved_objects == expected_result
+
+
+@pytest.mark.parametrize(
+    "input_recipe_data, expected_result",
+    [
+        (
+            {},
+            "1.0",
+        ),
+        (
+            {"format_version": "2.0.33"},
+            "2.0",
+        ),
+        (
+            {"format_version": "2.33.0"},
+            "2.33",
+        ),
+        (
+            {"format_version": "2.0"},
+            "2.0",
+        ),
+        (
+            {"format_version": "2.105"},
+            "2.105",
+        ),
+    ],
+)
+def test_sanitize_format_version(expected_result, input_recipe_data):
+    assert expected_result == RecipeLoader._sanitize_format_version(input_recipe_data)
+

--- a/cellpack/tests/test_recipe_loader.py
+++ b/cellpack/tests/test_recipe_loader.py
@@ -96,4 +96,3 @@ def test_resolve_objects():
 )
 def test_sanitize_format_version(expected_result, input_recipe_data):
     assert expected_result == RecipeLoader._sanitize_format_version(input_recipe_data)
-

--- a/cellpack/tests/test_recipe_version_migration.py
+++ b/cellpack/tests/test_recipe_version_migration.py
@@ -393,3 +393,8 @@ def test_migrate_version(converted_data, expected_data):
     assert converted_data["format_version"] == expected_data["format_version"]
     assert converted_data["name"] == expected_data["name"]
     assert converted_data["bounding_box"] == expected_data["bounding_box"]
+
+
+def test_migrate_version_error():
+    with pytest.raises(ValueError, match="0.0 is not a format vesion we support"):
+        RecipeLoader._migrate_version(None, {"format_version": "0.0"})

--- a/cellpack/tests/test_recipe_version_migration.py
+++ b/cellpack/tests/test_recipe_version_migration.py
@@ -396,5 +396,8 @@ def test_migrate_version(converted_data, expected_data):
 
 
 def test_migrate_version_error():
-    with pytest.raises(ValueError, match="0.0 is not a format vesion we support"):
-        RecipeLoader._migrate_version(None, {"format_version": "0.0"})
+    not_a_format_version = "0.0"
+    with pytest.raises(
+        ValueError, match=f"{not_a_format_version} is not a format vesion we support"
+    ):
+        RecipeLoader._migrate_version(None, {"format_version": not_a_format_version})


### PR DESCRIPTION
Problem
=======
The migrate code can return an empty object if the format version is wrong 

Solution
========
1. Check to see if the format version is 2.0.0 instead of 2.0 and fix it. 
2. Raise an error if the format version is something other than 1.0 or 2.0 (for now, will change as we add more supported versions)


## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)
* This change requires updated or new tests
