### PR TITLE
fix ingredient type checks

### DIFF
--- a/cellpack/autopack/interface_objects/ingredient_types.py
+++ b/cellpack/autopack/interface_objects/ingredient_types.py
@@ -1,7 +1,7 @@
-from enum import Enum
+from cellpack.autopack.interface_objects.meta_enum import MetaEnum
 
 
-class INGREDIENT_TYPE(Enum):
+class INGREDIENT_TYPE(str, MetaEnum):
     SINGLE_SPHERE = "single_sphere"
     MULTI_SPHERE = "multi_sphere"
     SINGLE_CUBE = "single_cube"

--- a/cellpack/autopack/interface_objects/ingredient_types.py
+++ b/cellpack/autopack/interface_objects/ingredient_types.py
@@ -1,7 +1,7 @@
 from cellpack.autopack.interface_objects.meta_enum import MetaEnum
 
 
-class INGREDIENT_TYPE(str, MetaEnum):
+class INGREDIENT_TYPE(MetaEnum):
     SINGLE_SPHERE = "single_sphere"
     MULTI_SPHERE = "multi_sphere"
     SINGLE_CUBE = "single_cube"

--- a/cellpack/autopack/interface_objects/meta_enum.py
+++ b/cellpack/autopack/interface_objects/meta_enum.py
@@ -1,7 +1,7 @@
 from enum import Enum
 
 
-class MetaEnum(Enum):
+class MetaEnum(str, Enum):
     @classmethod
     def values(cls):
         return [member.value for member in cls]

--- a/cellpack/autopack/interface_objects/meta_enum.py
+++ b/cellpack/autopack/interface_objects/meta_enum.py
@@ -1,0 +1,12 @@
+from enum import Enum
+
+
+class MetaEnum(Enum):
+    @classmethod
+    def values(cls):
+        return [member.value for member in cls]
+
+    @classmethod
+    def is_member(cls, item):
+        values = cls.values()
+        return item in values

--- a/cellpack/autopack/loaders/config_loader.py
+++ b/cellpack/autopack/loaders/config_loader.py
@@ -1,22 +1,12 @@
 # -*- coding: utf-8 -*-
-from enum import Enum
 import os
 
 import json
 from json import encoder
 
+from cellpack.autopack.interface_objects.meta_enum import MetaEnum
+
 encoder.FLOAT_REPR = lambda o: format(o, ".8g")
-
-
-class MetaEnum(Enum):
-    @classmethod
-    def values(cls):
-        return [member.value for member in cls]
-
-    @classmethod
-    def is_member(cls, item):
-        values = cls.values()
-        return item in values
 
 
 class Place_Methods(MetaEnum):

--- a/cellpack/autopack/loaders/recipe_loader.py
+++ b/cellpack/autopack/loaders/recipe_loader.py
@@ -6,6 +6,7 @@ import json
 from json import encoder
 
 import cellpack.autopack as autopack
+from cellpack.autopack.interface_objects.ingredient_types import INGREDIENT_TYPE
 from cellpack.autopack.utils import deep_merge
 from cellpack.autopack.interface_objects.representations import Representations
 from cellpack.autopack.interface_objects.default_values import default_recipe_values
@@ -178,6 +179,9 @@ class RecipeLoader(object):
                     atomic=reps.get("atomic", None),
                     packing=reps.get("packing", None),
                 )
+            if not INGREDIENT_TYPE.is_member(obj["type"]):
+                raise TypeError(f"{obj['type']} is not an allowed type")
+
         return recipe_data
 
     def _load_json(self):


### PR DESCRIPTION
Problem
=======
closes #93 

Solution
========
We don't actually need to convert the type, we just need to make sure the enums are typed as strings so `ingredient_type == INGREDIENT_TYPE.SINGLE_SPHERE` correctly evaluates 

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)
