### PR TITLE
Update github workflows to use Python 3.9

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install Dependencies
       run: |
         pip install --upgrade pip

--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.9]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
@@ -42,7 +42,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip
@@ -64,7 +64,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.9]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
@@ -34,7 +34,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup_requirements = [
 ]
 
 test_requirements = [
-    "black>=19.10b0",
+    "black>=19.10b0, <=23.0",
     "codecov>=2.1.4",
     "flake8>=3.8.3",
     "flake8-debugger>=3.2.1",

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,6 @@ extra_requirements = {
     "all": [
         *requirements,
         *dev_requirements,
-        *analysis_requirements,
     ],
 }
 


### PR DESCRIPTION
Problem
=======
Test and lint actions were failing due to incompatibility between linter and python version

Solution
========
Updated github actions to use python 3.9 

with @meganrm, @rugeli 

## Type of change
* Bug fix (non-breaking change which fixes an issue)


Change summary:
---------------
Python 3.8 changed to python 3.9 in github workflow

Steps to Verify:
----------------
Create PR on github

Keyfiles (delete if not relevant):
-----------------------
- Files in `.github/workflows/`
- `setup.py`
