### PR TITLE
Automatically update plotly figure size

### DIFF
--- a/cellpack/autopack/Analysis.py
+++ b/cellpack/autopack/Analysis.py
@@ -1559,6 +1559,14 @@ class AnalyseAP:
         print("time to run pack_grid", self.env.place_method, t2 - t1)
         print("num placed", len(self.env.molecules))
         if show_plotly_plot:
+            min_bound, max_bound = self.env.get_bounding_box_limits()
+            width = max_bound - min_bound
+            self.plotly.plot.update_xaxes(
+                range=[min_bound[0] - 0.2 * width[0], max_bound[0] + 0.2 * width[0]]
+            )
+            self.plotly.plot.update_yaxes(
+                range=[min_bound[1] - 0.2 * width[1], max_bound[1] + 0.2 * width[1]]
+            )
             self.plotly.update_title(
                 f"{self.env.place_method} took {str(round(t2 - t1, 2))}s, packed {len(self.env.molecules)}"
             )

--- a/cellpack/autopack/Environment.py
+++ b/cellpack/autopack/Environment.py
@@ -297,6 +297,15 @@ class Environment(CompartmentList):
             if compartment.name == compartment_name:
                 return compartment
 
+    def get_bounding_box_limits(self):
+        """
+        Returns the min and max limits for the bounding box
+        """
+        bb = numpy.array(self.boundingBox)
+        min_bound = numpy.min(bb, axis=0)
+        max_bound = numpy.max(bb, axis=0)
+        return min_bound, max_bound
+
     def setSeed(self, seedNum):
         SEED = int(seedNum)
         numpy.random.seed(SEED)  # for gradient


### PR DESCRIPTION
Problem
=======
Plotly grid figures use a fixed width for the bounding box, causing visualization issues when non-standard bounding boxes are used.

Solution
========
The plotly figure dimensions are now automatically calculated from the bounding box.

## Type of change
* Bug fix (non-breaking change which fixes an issue)


Change summary:
---------------
plotly figure dimensions are now automatically calculated from the bounding box.

Steps to Verify:
----------------
1. `conda activate autopack`
2. `pack -r cellpack/test-recipes/v2/one_sphere.json -c packing-configs/debug.json`

Screenshots:
----------------
![image](https://user-images.githubusercontent.com/101426188/222834882-53f39079-e115-45f0-a73c-a966eb1a2127.png)

![image](https://user-images.githubusercontent.com/101426188/222836208-d258ff51-6066-45b2-8304-7eacfb3b4ab8.png)


Keyfiles (delete if not relevant):
-----------------------
1. `cellpack/autopack/Analysis.py`
4. `cellpack/autopack/Environment.py`