### PR TITLE
Fix overlapping plotly plots

### DIFF
--- a/cellpack/autopack/Analysis.py
+++ b/cellpack/autopack/Analysis.py
@@ -1616,6 +1616,8 @@ class AnalyseAP:
         if show_plotly_plot:
             min_bound, max_bound = self.env.get_bounding_box_limits()
             width = max_bound - min_bound
+            self.plotly.plot["data"] = []
+            self.plotly.plot.layout.shapes = ()
             self.plotly.plot.update_xaxes(
                 range=[min_bound[0] - 0.2 * width[0], max_bound[0] + 0.2 * width[0]]
             )

--- a/cellpack/autopack/loaders/config_loader.py
+++ b/cellpack/autopack/loaders/config_loader.py
@@ -29,7 +29,7 @@ class ConfigLoader(object):
         "load_from_grid_file": False,
         "inner_grid_method": "trimesh",
         "live_packing": False,
-        "num_trials": 1,
+        "number_of_packings": 1,
         "name": "default",
         "ordered_packing": False,
         "out": "out/",

--- a/cellpack/bin/pack.py
+++ b/cellpack/bin/pack.py
@@ -42,7 +42,7 @@ def pack(recipe, config=None):
         analyze = AnalyseAP(env=env, viewer=afviewer, result_file=None)
         log.info(f"saving to {env.out_folder}")
         analyze.doloop(
-            config_data["num_trials"],
+            config_data["number_of_packings"],
             env.boundingBox,
             plot_figures=config_data.get("save_plot_figures", True),
             show_grid=config_data["show_grid_plot"],

--- a/examples/packing-configs/debug.json
+++ b/examples/packing-configs/debug.json
@@ -9,6 +9,7 @@
     "place_method": "jitter",
     "save_analyze_result": true,
     "show_grid_plot": true,
+    "number_of_packings": 1,
     "spacing": null,
     "use_periodicity": false,
     "show_sphere_trees": true,

--- a/examples/packing-configs/peroxisome_packing_config.json
+++ b/examples/packing-configs/peroxisome_packing_config.json
@@ -4,7 +4,7 @@
     "inner_grid_method": "trimesh",
     "live_packing": false,
     "ordered_packing": false,
-    "num_trials": 1,
+    "number_of_packings": 1,
     "out": "out/analyze",
     "overwrite_place_method": true,
     "place_method": "spheresSST",


### PR DESCRIPTION
Problem
=======
Closes #48 

Solution
========
clear data and shapes before each packing

## Type of change
* Bug fix (non-breaking change which fixes an issue)

Change summary:
---------------
* changed `num_trials` parameter to `number_of_packings`
* clear plotly data and shapes before each packing

Steps to Verify:
----------------
1. change `number_of_packings` in `examples/packing-configs/debug.json` to a number greater than 1
1. `conda activate autopack`
1. `pack -r examples/recipes/v2/one_sphere.json examples/packing-configs/debug.json`

You should now get a separate plot for each packing instance. Note that a large number of packings will create multiple plots and increase computational load.

Keyfiles (delete if not relevant):
-----------------------
1. Analysis.py
