### PR TITLE
resolve compartment object for surface gradient

### DIFF
--- a/cellpack/autopack/Environment.py
+++ b/cellpack/autopack/Environment.py
@@ -793,6 +793,19 @@ class Environment(CompartmentList):
             if o.surfaceRecipe:
                 o.surfaceRecipe.sort()
 
+    def resolve_gradient_data_objects(self, gradient_data):
+        """
+        Resolves gradient data objects for some modes
+        """
+        # TODO: check if other modes need to be resolved
+        if gradient_data["mode"] == "surface":
+            gradient_data["mode_settings"][
+                "object"
+            ] = self.get_compartment_object_by_name(
+                gradient_data["mode_settings"]["object"]
+            )
+        return gradient_data
+
     def set_gradient(self, gradient_data):
         """
         create a grdaient
@@ -800,10 +813,7 @@ class Environment(CompartmentList):
         listorganelle influenced
         listingredient influenced
         """
-        if "surface_name" in gradient_data:
-            gradient_data["object"] = self.get_compartment_object_by_name(
-                gradient_data["surface_name"]
-            )
+        gradient_data = self.resolve_gradient_data_objects(gradient_data)
         gradient = Gradient(gradient_data)
         # default gradient 1-linear Decoy X
         self.gradients[gradient_data["name"]] = gradient
@@ -1369,7 +1379,7 @@ class Environment(CompartmentList):
             for g in self.gradients:
                 gradient = self.gradients[g]
                 if gradient.mode == "surface":
-                    gradient.object.get_surface_distances(
+                    gradient.mode_settings["object"].get_surface_distances(
                         self, self.grid.masterGridPositions
                     )
                 self.gradients[g].build_weight_map(

--- a/cellpack/autopack/Gradient.py
+++ b/cellpack/autopack/Gradient.py
@@ -157,12 +157,17 @@ class Gradient:
         build a map of weights based on the distance from a surface
         assumes self.distances include surface distances
         """
-        if getattr(self.object, "surface_distances", None) is None:
+        if getattr(self.mode_settings["object"], "surface_distances", None) is None:
             raise ValueError("Surface distances are not set")
-        elif self.scale_to_next_surface:
-            self.distances = self.object.scaled_distance_to_next_surface
+        elif self.mode_settings["scale_to_next_surface"]:
+            self.distances = self.mode_settings[
+                "object"
+            ].scaled_distance_to_next_surface
         else:
-            self.distances = self.object.surface_distances / self.object.max_distance
+            self.distances = (
+                self.mode_settings["object"].surface_distances
+                / self.mode_settings["object"].max_distance
+            )
         self.set_weights_by_mode()
 
     def build_directional_weight_map(self, bb, master_grid_positions):


### PR DESCRIPTION
Problem
=======
Surface gradient recipes require a compartment object as input, which was not being resolved while reading in the gradient data.

Solution
========
Added a function to resolve a compartment for the surface gradient mode
with @rugeli 

## Type of change
* Bug fix (non-breaking change which fixes an issue)
* This change requires updated or new tests

Change summary:
---------------
resolved compartment object for surface gradient

Steps to Verify:
----------------
1. `conda activate autopack`
2. pack -r examples/recipes/v2/peroxisomes_surface_gradient.json -c examples/packing-configs/peroxisome_packing_config.json

Keyfiles (delete if not relevant):
-----------------------
1. Environment.py
2. Gradient.py
