### PR TITLE
Feature/resovle grads in comp

### DIFF
--- a/cellpack/autopack/DBRecipeHandler.py
+++ b/cellpack/autopack/DBRecipeHandler.py
@@ -58,7 +58,7 @@ class CompositionDoc(DataDoc):
 
     @staticmethod
     def get_gradient_reference(downloaded_data, db):
-        if db.is_reference(downloaded_data["gradient"]):
+        if "gradient" in downloaded_data and db.is_reference(downloaded_data["gradient"]):
             gradient_key = downloaded_data["gradient"]
             downloaded_data["gradient"], _ = db.get_doc_by_ref(gradient_key)
 
@@ -72,17 +72,15 @@ class CompositionDoc(DataDoc):
         if DataDoc.is_key(key_or_dict) and db.is_reference(key_or_dict):
             key = key_or_dict
             downloaded_data, _ = db.get_doc_by_ref(key)
-            if "gradient" in downloaded_data:
-                CompositionDoc.get_gradient_reference(downloaded_data, db)
+            CompositionDoc.get_gradient_reference(downloaded_data, db)
             return downloaded_data, None
         elif key_or_dict and isinstance(key_or_dict, dict):
             object_dict = key_or_dict
             if "object" in object_dict and db.is_reference(object_dict["object"]):
                 key = object_dict["object"]
                 downloaded_data, _ = db.get_doc_by_ref(key)
-                if "gradient" in downloaded_data:
-                    CompositionDoc.get_gradient_reference(downloaded_data, db)
-                    return downloaded_data, key
+                CompositionDoc.get_gradient_reference(downloaded_data, db)
+                return downloaded_data, key
         return {}, None
 
     def resolve_db_regions(self, db_data, db):
@@ -149,17 +147,19 @@ class CompositionDoc(DataDoc):
                             "object"
                         ] = prep_recipe_data["objects"][obj_item]
                     else:
-                        # replace gradient reference with gradient data
-                        if "gradient" in obj_item and isinstance(
-                            obj_item["gradient"], str
-                        ):
-                            local_data["regions"][region_name][index]["object"][
-                                "gradient"
-                            ] = prep_recipe_data["gradients"][obj_item["gradient"]]
-                        else:
-                            local_data["regions"][region_name][index][
-                                "object"
-                            ] = prep_recipe_data["objects"][obj_item["name"]]
+                        local_data["regions"][region_name][index][
+                            "object"
+                        ] = prep_recipe_data["objects"][obj_item["name"]]
+                    # replace gradient reference with gradient data
+                    obj_data = local_data["regions"][region_name][index][
+                            "object"
+                        ]
+                    if "gradient" in obj_data and isinstance(
+                        obj_data["gradient"], str
+                    ):
+                        local_data["regions"][region_name][index]["object"][
+                            "gradient"
+                        ] = prep_recipe_data["gradients"][obj_data["gradient"]]
                 else:
                     comp_name = local_data["regions"][region_name][index]
                     prep_comp_data = prep_recipe_data["composition"][comp_name]
@@ -429,7 +429,6 @@ class DBRecipeHandler(object):
             else:
                 _, grad_path = self.upload_data("gradients", gradient_doc.settings)
                 self.grad_to_path_map[gradient_name] = grad_path
-                print("grad_path", self.grad_to_path_map)
 
     def upload_objects(self, objects):
         for obj_name in objects:

--- a/cellpack/autopack/DBRecipeHandler.py
+++ b/cellpack/autopack/DBRecipeHandler.py
@@ -432,6 +432,8 @@ class DBRecipeHandler(object):
             _, doc_id = object_doc.should_write(self.db)
             if doc_id:
                 print(f"objects/{object_doc.name} is already in firestore")
+                obj_path = self.db.create_path("objects", doc_id)
+                self.objects_to_path_map[obj_name] = obj_path
             else:
                 _, obj_path = self.upload_data("objects", object_doc.as_dict())
                 self.objects_to_path_map[obj_name] = obj_path

--- a/cellpack/autopack/DBRecipeHandler.py
+++ b/cellpack/autopack/DBRecipeHandler.py
@@ -362,14 +362,6 @@ class DBRecipeHandler(object):
         )
 
     @staticmethod
-    def is_db_dict(item):
-        if isinstance(item, dict) and len(item) > 0:
-            for key, value in item.items():
-                if key.isdigit() and isinstance(value, list):
-                    return True
-        return False
-
-    @staticmethod
     def prep_data_for_db(data):
         """
         Recursively convert data to a format that can be written to the database.
@@ -537,7 +529,7 @@ class DBRecipeHandler(object):
         recipe, _ = self.db.get_doc_by_id("recipes", recipe_id)
         if recipe:
             print(f"{recipe_id} is already in firestore")
-            # return
+            return
         recipe_to_save = self.upload_collections(recipe_meta_data, recipe_data)
         key = self.get_recipe_id(recipe_to_save)
         self.upload_data("recipes", recipe_to_save, key)

--- a/cellpack/autopack/DBRecipeHandler.py
+++ b/cellpack/autopack/DBRecipeHandler.py
@@ -523,41 +523,18 @@ class DBRecipeHandler(object):
                 elif key == "composition":
                     compositions = db_doc["composition"]
                     for comp_name, reference in compositions.items():
-                        comp_obj = compositions[comp_name]
-                        ref_link = comp_obj["inherit"]
-                        comp_data = deep_merge(
-                            copy.deepcopy(CompositionDoc.DEFAULT_VALUES), comp_obj
-                        )
+                        ref_link = reference["inherit"]
                         comp_doc = CompositionDoc(
-                                name=None,
-                                object_key=comp_data["object"],
-                                count=comp_data["count"],
-                                regions=comp_data["regions"],
-                                molarity=comp_data["molarity"],
+                                comp_name,
+                                object_key=None,
+                                count=None,
+                                regions={},
+                                molarity=None,
                             )
                         composition_data, _ = comp_doc.get_reference_data(ref_link, self.db)
-                        resolved_regions_comp = comp_doc.resolve_db_regions(composition_data, self.db)
+                        comp_doc.resolve_db_regions(composition_data, self.db)
                         compositions[comp_name] = composition_data
                     prep_data[key] = compositions
                 else:
                     prep_data[key] = value
         return prep_data
-
-    def fetch_and_merge_db_data(self, db_doc):
-        # convert db data to original recipe data
-        prep_data = self.prep_db_doc_for_download(db_doc)
-        print("prep_data", json.dumps(prep_data, sort_keys=True, indent=4))
-        converted_recipe_data = {}
-        obj_dict = {}
-        for item in prep_data:
-            if item == "composition":
-                for comp_name, comp_data in prep_data[item].items():
-                    converted_recipe_data["composition"][comp_name] = comp_data
-                    if "object" in comp_data:
-                        obj_name = comp_data["object"]["name"]
-                        obj_dict[obj_name] = comp_data["object"]
-                # converted_recipe_data[] = prep_data[item]
-            else: 
-                converted_recipe_data[item] = prep_data[item]
-        
-        return "recipe_data", prep_data

--- a/cellpack/autopack/DBRecipeHandler.py
+++ b/cellpack/autopack/DBRecipeHandler.py
@@ -329,6 +329,14 @@ class DBRecipeHandler(object):
             and len(item) > 0
             and isinstance(item[0], (list, tuple))
         )
+    
+    @staticmethod
+    def is_db_dict(item):
+        if isinstance(item, dict) and len(item) > 0:
+            for key, value in item.items():
+                if key.isdigit() and isinstance(value, list):
+                    return True
+        return False
 
     @staticmethod
     def prep_data_for_db(data):
@@ -493,3 +501,19 @@ class DBRecipeHandler(object):
         recipe_to_save = self.upload_collections(recipe_meta_data, recipe_data)
         key = self.get_recipe_id(recipe_to_save)
         self.upload_data("recipes", recipe_to_save, key)
+
+    def prep_db_doc_for_download(self, db_doc):
+        """
+        Recursively convert data from db to a format that can be read by recipe loader.
+        """
+        prep_data = {}
+        for key, value in db_doc.items():
+            if self.is_db_dict(value):
+                return "yes"
+            
+
+    def fetch_and_merge_db_data(self, db_doc):
+        # convert db data to original recipe data
+        prep_db_data = self.prep_db_doc_for_download(db_doc)
+        return "recipe_data", prep_db_data
+    

--- a/cellpack/autopack/DBRecipeHandler.py
+++ b/cellpack/autopack/DBRecipeHandler.py
@@ -134,7 +134,6 @@ class CompositionDoc(DataDoc):
             else:
                 key_name = local_data["object"]["name"]
             local_data["object"] = prep_recipe_data["objects"][key_name]
-            # TODO: check if there is a case where gradient is inside of a comp but not in regions
             if "gradient" in local_data["object"] and isinstance(
                 local_data["object"]["gradient"], str
             ):

--- a/cellpack/autopack/DBRecipeHandler.py
+++ b/cellpack/autopack/DBRecipeHandler.py
@@ -58,7 +58,9 @@ class CompositionDoc(DataDoc):
 
     @staticmethod
     def get_gradient_reference(downloaded_data, db):
-        if "gradient" in downloaded_data and db.is_reference(downloaded_data["gradient"]):
+        if "gradient" in downloaded_data and db.is_reference(
+            downloaded_data["gradient"]
+        ):
             gradient_key = downloaded_data["gradient"]
             downloaded_data["gradient"], _ = db.get_doc_by_ref(gradient_key)
 
@@ -151,12 +153,8 @@ class CompositionDoc(DataDoc):
                             "object"
                         ] = prep_recipe_data["objects"][obj_item["name"]]
                     # replace gradient reference with gradient data
-                    obj_data = local_data["regions"][region_name][index][
-                            "object"
-                        ]
-                    if "gradient" in obj_data and isinstance(
-                        obj_data["gradient"], str
-                    ):
+                    obj_data = local_data["regions"][region_name][index]["object"]
+                    if "gradient" in obj_data and isinstance(obj_data["gradient"], str):
                         local_data["regions"][region_name][index]["object"][
                             "gradient"
                         ] = prep_recipe_data["gradients"][obj_data["gradient"]]
@@ -543,4 +541,3 @@ class DBRecipeHandler(object):
         recipe_to_save = self.upload_collections(recipe_meta_data, recipe_data)
         key = self.get_recipe_id(recipe_to_save)
         self.upload_data("recipes", recipe_to_save, key)
-

--- a/cellpack/autopack/DBRecipeHandler.py
+++ b/cellpack/autopack/DBRecipeHandler.py
@@ -539,38 +539,8 @@ class DBRecipeHandler(object):
         recipe, _ = self.db.get_doc_by_id("recipes", recipe_id)
         if recipe:
             print(f"{recipe_id} is already in firestore")
-            return
+            # return
         recipe_to_save = self.upload_collections(recipe_meta_data, recipe_data)
         key = self.get_recipe_id(recipe_to_save)
         self.upload_data("recipes", recipe_to_save, key)
 
-    def prep_db_doc_for_download(self, db_doc):
-        """
-        convert data from db and resolve references.
-        """
-        prep_data = {}
-        if isinstance(db_doc, dict):
-            for key, value in db_doc.items():
-                if self.is_db_dict(value):
-                    unpack_dict = [value[str(i)] for i in range(len(value))]
-                    prep_data[key] = unpack_dict
-                elif key == "composition":
-                    compositions = db_doc["composition"]
-                    for comp_name, reference in compositions.items():
-                        ref_link = reference["inherit"]
-                        comp_doc = CompositionDoc(
-                            comp_name,
-                            object_key=None,
-                            count=None,
-                            regions={},
-                            molarity=None,
-                        )
-                        composition_data, _ = comp_doc.get_reference_data(
-                            ref_link, self.db
-                        )
-                        comp_doc.resolve_db_regions(composition_data, self.db)
-                        compositions[comp_name] = composition_data
-                    prep_data[key] = compositions
-                else:
-                    prep_data[key] = value
-        return prep_data

--- a/cellpack/autopack/DBRecipeHandler.py
+++ b/cellpack/autopack/DBRecipeHandler.py
@@ -101,6 +101,17 @@ class CompositionDoc(DataDoc):
                 ):
                     self.resolve_db_regions(downloaded_data, db)
 
+    @staticmethod
+    def gradient_list_to_dict(prep_recipe_data):
+        """
+        Convert gradient list to dict for resolve_local_regions
+        """
+        if "gradients" in prep_recipe_data and isinstance(prep_recipe_data["gradients"], list):
+            gradient_dict = {}
+            for gradient in prep_recipe_data["gradients"]:
+                gradient_dict[gradient["name"]] = gradient
+            prep_recipe_data["gradients"] = gradient_dict
+            
     def resolve_local_regions(self, local_data, recipe_data, db):
         """
         Recursively resolves the regions of a composition from local data.
@@ -108,14 +119,17 @@ class CompositionDoc(DataDoc):
         """
         unpack_recipe_data = DBRecipeHandler.prep_data_for_db(recipe_data)
         prep_recipe_data = ObjectDoc.convert_representation(unpack_recipe_data, db)
+        # `gradients` is a list, convert it to dict for easy access and replace
+        CompositionDoc.gradient_list_to_dict(prep_recipe_data)
         if "object" in local_data and local_data["object"] is not None:
-            if "gradient" in local_data["object"] and db.is_reference(local_data["object"]["gradient"]):
-                local_data["object"]["gradient"] = prep_recipe_data["gradients"][local_data["object"]["gradient"]]
             if DataDoc.is_key(local_data["object"]):
                 key_name = local_data["object"]
             else:
                 key_name = local_data["object"]["name"]
             local_data["object"] = prep_recipe_data["objects"][key_name]
+            #TODO: check if there is a case where gradient is inside of a comp but not in regions
+            if "gradient" in local_data["object"] and isinstance(local_data["object"]["gradient"], str):
+                local_data["object"]["gradient"] = prep_recipe_data["gradients"][local_data["object"]["gradient"]]
         for region_name in local_data["regions"]:
             for index, key_or_dict in enumerate(local_data["regions"][region_name]):
                 if not DataDoc.is_key(key_or_dict):
@@ -126,8 +140,8 @@ class CompositionDoc(DataDoc):
                         ] = prep_recipe_data["objects"][obj_item]
                     else:
                         #replace gradient reference with gradient data
-                        if "gradient" in obj_item and db.is_reference(obj_item["gradient"]):
-                            local_data["regions"][region_name][index]["object"]["gradient"] = db.get_doc_by_ref(obj_item["gradient"])[0]
+                        if "gradient" in obj_item and isinstance(obj_item["gradient"], str):
+                            local_data["regions"][region_name][index]["object"]["gradient"] = prep_recipe_data["gradients"][obj_item["gradient"]]
                         else:
                             local_data["regions"][region_name][index][
                                 "object"
@@ -406,11 +420,12 @@ class DBRecipeHandler(object):
     def upload_objects(self, objects):
         for obj_name in objects:
             objects[obj_name]["name"] = obj_name
-            object_doc = ObjectDoc(name=obj_name, settings=objects[obj_name])
+            modify_objects = copy.deepcopy(objects)
             # replace gradient name with path before uploading
-            if "gradient" in objects[obj_name]:
-                grad_name = objects[obj_name]["gradient"]
-                objects[obj_name]["gradient"] = self.grad_to_path_map[grad_name]
+            if "gradient" in modify_objects[obj_name]:
+                grad_name = modify_objects[obj_name]["gradient"]
+                modify_objects[obj_name]["gradient"] = self.grad_to_path_map[grad_name]
+            object_doc = ObjectDoc(name=obj_name, settings=modify_objects[obj_name])
             _, doc_id = object_doc.should_write(self.db)
             if doc_id:
                 print(f"objects/{object_doc.name} is already in firestore")
@@ -511,7 +526,7 @@ class DBRecipeHandler(object):
         recipe, _ = self.db.get_doc_by_id("recipes", recipe_id)
         if recipe:
             print(f"{recipe_id} is already in firestore")
-            # return
+            #return
         recipe_to_save = self.upload_collections(recipe_meta_data, recipe_data)
         key = self.get_recipe_id(recipe_to_save)
         self.upload_data("recipes", recipe_to_save, key)

--- a/cellpack/autopack/DBRecipeHandler.py
+++ b/cellpack/autopack/DBRecipeHandler.py
@@ -1,5 +1,7 @@
 import copy
 
+import json
+
 from deepdiff import DeepDiff
 
 from cellpack.autopack.utils import deep_merge
@@ -72,6 +74,9 @@ class CompositionDoc(DataDoc):
             if "object" in object_dict and db.is_reference(object_dict["object"]):
                 key = object_dict["object"]
                 downloaded_data, _ = db.get_doc_by_ref(key)
+                if "gradient" in downloaded_data and db.is_reference(downloaded_data["gradient"]):
+                    gradient_key = downloaded_data["gradient"]
+                    downloaded_data["gradient"], _ = db.get_doc_by_ref(gradient_key)
                 return downloaded_data, key
         return {}, None
 
@@ -500,7 +505,7 @@ class DBRecipeHandler(object):
         recipe, _ = self.db.get_doc_by_id("recipes", recipe_id)
         if recipe:
             print(f"{recipe_id} is already in firestore")
-            return
+            # return
         recipe_to_save = self.upload_collections(recipe_meta_data, recipe_data)
         key = self.get_recipe_id(recipe_to_save)
         self.upload_data("recipes", recipe_to_save, key)

--- a/cellpack/autopack/DBRecipeHandler.py
+++ b/cellpack/autopack/DBRecipeHandler.py
@@ -109,6 +109,8 @@ class CompositionDoc(DataDoc):
         unpack_recipe_data = DBRecipeHandler.prep_data_for_db(recipe_data)
         prep_recipe_data = ObjectDoc.convert_representation(unpack_recipe_data, db)
         if "object" in local_data and local_data["object"] is not None:
+            if "gradient" in local_data["object"] and db.is_reference(local_data["object"]["gradient"]):
+                local_data["object"]["gradient"] = prep_recipe_data["gradients"][local_data["object"]["gradient"]]
             if DataDoc.is_key(local_data["object"]):
                 key_name = local_data["object"]
             else:
@@ -123,9 +125,13 @@ class CompositionDoc(DataDoc):
                             "object"
                         ] = prep_recipe_data["objects"][obj_item]
                     else:
-                        local_data["regions"][region_name][index][
-                            "object"
-                        ] = prep_recipe_data["objects"][obj_item["name"]]
+                        #replace gradient reference with gradient data
+                        if "gradient" in obj_item and db.is_reference(obj_item["gradient"]):
+                            local_data["regions"][region_name][index]["object"]["gradient"] = db.get_doc_by_ref(obj_item["gradient"])[0]
+                        else:
+                            local_data["regions"][region_name][index][
+                                "object"
+                            ] = prep_recipe_data["objects"][obj_item["name"]]
                 else:
                     comp_name = local_data["regions"][region_name][index]
                     prep_comp_data = prep_recipe_data["composition"][comp_name]

--- a/cellpack/autopack/FirebaseHandler.py
+++ b/cellpack/autopack/FirebaseHandler.py
@@ -51,6 +51,8 @@ class FirebaseHandler(object):
 
     @staticmethod
     def is_reference(path):
+        if not isinstance(path, str):
+            return False
         if path is None:
             return False
         if path.startswith("firebase:"):

--- a/cellpack/autopack/__init__.py
+++ b/cellpack/autopack/__init__.py
@@ -394,7 +394,7 @@ def load_file(filename, destination="", cache="geometries", force=None):
             db_doc, _ = db.get_doc_by_id(collection="recipes", id=recipe_id)
             db_handler = DBRecipeHandler(db)
             downloaded_recipe_data = db_handler.prep_db_doc_for_download(db_doc)
-            return downloaded_recipe_data
+            return downloaded_recipe_data, database_name
         else:
             local_file_path = get_local_file_location(
                 file_path, destination=destination, cache=cache, force=force
@@ -403,7 +403,7 @@ def load_file(filename, destination="", cache="geometries", force=None):
         local_file_path = get_local_file_location(
             filename, destination=destination, cache=cache, force=force
         )
-    return json.load(open(local_file_path, "r"))
+    return json.load(open(local_file_path, "r")), None
 
 
 def fixPath(adict):  # , k, v):

--- a/cellpack/autopack/__init__.py
+++ b/cellpack/autopack/__init__.py
@@ -387,7 +387,7 @@ def load_file(filename, destination="", cache="geometries", force=None):
     # what is the param destination for? should we use it to store db names?
     if is_remote_path(filename):
         database_name, file_path = convert_db_shortname_to_url(filename)
-        # command example: `pack -r firebase:recipes/gradients_v-default -c examples/packing-configs/run.json`
+        # command example: `pack -r firebase:recipes/peroxisomes_surface_gradient_v-linear -c examples/packing-configs/run.json`
         if database_name == "firebase":
             recipe_id = file_path.split("/")[-1]
             db = FirebaseHandler("cred")  # cred = personal firebase credentials

--- a/cellpack/autopack/__init__.py
+++ b/cellpack/autopack/__init__.py
@@ -390,7 +390,7 @@ def load_file(filename, destination="", cache="geometries", force=None):
         # command example: `pack -r firebase:recipes/gradients_v-default -c examples/packing-configs/run.json`
         if database_name == "firebase":
             recipe_id = file_path.split("/")[-1]
-            db = FirebaseHandler("cred") #cred = personal firebase credentials
+            db = FirebaseHandler("cred")  # cred = personal firebase credentials
             db_doc, _ = db.get_doc_by_id(collection="recipes", id=recipe_id)
             db_handler = DBRecipeHandler(db)
             downloaded_recipe_data = db_handler.prep_db_doc_for_download(db_doc)

--- a/cellpack/autopack/__init__.py
+++ b/cellpack/autopack/__init__.py
@@ -393,9 +393,8 @@ def load_file(filename, destination="", cache="geometries", force=None):
             db = FirebaseHandler("/Users/Ruge/Desktop/Allen Internship/cellPACK/cellpack-data-582d6-firebase-adminsdk-3pkkz-27a3ec0777.json") #cred = personal firebase credentials
             db_doc, _ = db.get_doc_by_id(collection="recipes", id=recipe_id)
             db_handler = DBRecipeHandler(db)
-            converted_recipe_data = db_handler.fetch_and_merge_db_data(db_doc)
-            print("converted_recipe_data", converted_recipe_data)
-            return db_doc
+            downloaded_recipe_data = db_handler.prep_db_doc_for_download(db_doc)
+            return downloaded_recipe_data
         else:
             local_file_path = get_local_file_location(
                 file_path, destination=destination, cache=cache, force=force

--- a/cellpack/autopack/__init__.py
+++ b/cellpack/autopack/__init__.py
@@ -390,7 +390,7 @@ def load_file(filename, destination="", cache="geometries", force=None):
         # command example: `pack -r firebase:recipes/gradients_v-default -c examples/packing-configs/run.json`
         if database_name == "firebase":
             recipe_id = file_path.split("/")[-1]
-            db = FirebaseHandler(cred) #cred = personal firebase credentials
+            db = FirebaseHandler("/Users/Ruge/Desktop/Allen Internship/cellPACK/cellpack-data-582d6-firebase-adminsdk-3pkkz-27a3ec0777.json") #cred = personal firebase credentials
             db_doc, _ = db.get_doc_by_id(collection="recipes", id=recipe_id)
             db_handler = DBRecipeHandler(db)
             converted_recipe_data = db_handler.fetch_and_merge_db_data(db_doc)

--- a/cellpack/autopack/__init__.py
+++ b/cellpack/autopack/__init__.py
@@ -384,17 +384,12 @@ def read_text_file(filename, destination="", cache="collisionTrees", force=None)
 
 
 def load_file(filename, destination="", cache="geometries", force=None):
-    # what is the param destination for? should we use it to store db names?
     if is_remote_path(filename):
         database_name, file_path = convert_db_shortname_to_url(filename)
-        # command example: `pack -r firebase:recipes/peroxisomes_surface_gradient_v-linear -c examples/packing-configs/run.json`
         if database_name == "firebase":
-            recipe_id = file_path.split("/")[-1]
-            db = FirebaseHandler("cred")  # cred = personal firebase credentials
-            db_doc, _ = db.get_doc_by_id(collection="recipes", id=recipe_id)
-            db_handler = DBRecipeHandler(db)
-            downloaded_recipe_data = db_handler.prep_db_doc_for_download(db_doc)
-            return downloaded_recipe_data, database_name
+            # TODO: read from firebase
+            # return data
+            pass
         else:
             local_file_path = get_local_file_location(
                 file_path, destination=destination, cache=cache, force=force
@@ -403,7 +398,7 @@ def load_file(filename, destination="", cache="geometries", force=None):
         local_file_path = get_local_file_location(
             filename, destination=destination, cache=cache, force=force
         )
-    return json.load(open(local_file_path, "r")), None
+    return json.load(open(local_file_path, "r"))
 
 
 def fixPath(adict):  # , k, v):

--- a/cellpack/autopack/__init__.py
+++ b/cellpack/autopack/__init__.py
@@ -282,7 +282,7 @@ def is_remote_path(file_path):
     """
     for ele in DATABASE_NAME:
         if ele in file_path:
-            return ele in file_path
+            return True
 
 
 def convert_db_shortname_to_url(file_location):

--- a/cellpack/autopack/__init__.py
+++ b/cellpack/autopack/__init__.py
@@ -390,7 +390,7 @@ def load_file(filename, destination="", cache="geometries", force=None):
         # command example: `pack -r firebase:recipes/gradients_v-default -c examples/packing-configs/run.json`
         if database_name == "firebase":
             recipe_id = file_path.split("/")[-1]
-            db = FirebaseHandler("/Users/Ruge/Desktop/Allen Internship/cellPACK/cellpack-data-582d6-firebase-adminsdk-3pkkz-27a3ec0777.json") #cred = personal firebase credentials
+            db = FirebaseHandler("cred") #cred = personal firebase credentials
             db_doc, _ = db.get_doc_by_id(collection="recipes", id=recipe_id)
             db_handler = DBRecipeHandler(db)
             downloaded_recipe_data = db_handler.prep_db_doc_for_download(db_doc)

--- a/cellpack/autopack/__init__.py
+++ b/cellpack/autopack/__init__.py
@@ -48,6 +48,8 @@ import ssl
 import json
 
 from cellpack.autopack.interface_objects.meta_enum import MetaEnum
+from cellpack.autopack.FirebaseHandler import FirebaseHandler
+from cellpack.autopack.DBRecipeHandler import DBRecipeHandler
 
 
 packageContainsVFCommands = 1
@@ -281,7 +283,8 @@ def is_remote_path(file_path):
     @param file_path: str
     """
     for ele in DATABASE_NAME:
-        return ele in file_path
+        if ele in file_path:
+            return ele in file_path
 
 
 def convert_db_shortname_to_url(file_location):
@@ -381,12 +384,19 @@ def read_text_file(filename, destination="", cache="collisionTrees", force=None)
 
 
 def load_file(filename, destination="", cache="geometries", force=None):
+    # what is the param destination for? should we use it to store db names?
     if is_remote_path(filename):
         database_name, file_path = convert_db_shortname_to_url(filename)
+        # command example: `pack -r firebase:recipes/gradients_v-default -c examples/packing-configs/run.json`
         if database_name == "firebase":
-            # TODO: read from firebase
-            # return data
-            pass
+            recipe_id = file_path.split("/")[-1]
+            db = FirebaseHandler(cred) #cred = personal firebase credentials
+            db_doc, _ = db.get_doc_by_id(collection="recipes", id=recipe_id)
+            db_handler = DBRecipeHandler(db)
+            converted_recipe_data = db_handler.fetch_and_merge_db_data(db_doc)
+            print("db_doc", db_doc)
+            print("converted_recipe_data", converted_recipe_data)
+            return db_doc
         else:
             local_file_path = get_local_file_location(
                 file_path, destination=destination, cache=cache, force=force

--- a/cellpack/autopack/__init__.py
+++ b/cellpack/autopack/__init__.py
@@ -394,7 +394,6 @@ def load_file(filename, destination="", cache="geometries", force=None):
             db_doc, _ = db.get_doc_by_id(collection="recipes", id=recipe_id)
             db_handler = DBRecipeHandler(db)
             converted_recipe_data = db_handler.fetch_and_merge_db_data(db_doc)
-            print("db_doc", db_doc)
             print("converted_recipe_data", converted_recipe_data)
             return db_doc
         else:

--- a/cellpack/autopack/__init__.py
+++ b/cellpack/autopack/__init__.py
@@ -48,8 +48,6 @@ import ssl
 import json
 
 from cellpack.autopack.interface_objects.meta_enum import MetaEnum
-from cellpack.autopack.FirebaseHandler import FirebaseHandler
-from cellpack.autopack.DBRecipeHandler import DBRecipeHandler
 
 
 packageContainsVFCommands = 1

--- a/cellpack/autopack/loaders/migrate_v1_to_v2.py
+++ b/cellpack/autopack/loaders/migrate_v1_to_v2.py
@@ -121,7 +121,7 @@ def split_ingredient_data(object_key, ingredient_data):
 
 def get_and_store_v2_object(ingredient_key, ingredient_data, region_list, objects_dict):
     if "include" in ingredient_data:
-        ingredient_data, _ = load_file(ingredient_data["include"], cache="recipes")
+        ingredient_data = load_file(ingredient_data["include"], cache="recipes")
     check_required_attributes(ingredient_data)
     converted_ingredient = migrate_ingredient(ingredient_data)
     object_info, composition_info = split_ingredient_data(

--- a/cellpack/autopack/loaders/migrate_v1_to_v2.py
+++ b/cellpack/autopack/loaders/migrate_v1_to_v2.py
@@ -145,6 +145,7 @@ def convert(old_recipe):
     new_recipe["name"] = old_recipe["recipe"]["name"]
     new_recipe["bounding_box"] = old_recipe["options"]["boundingBox"]
     objects_dict = {}
+    #TODO: check if composition structure is correct
     composition = {"space": {"regions": {}}}
     if "cytoplasme" in old_recipe:
         outer_most_region_array = []

--- a/cellpack/autopack/loaders/migrate_v1_to_v2.py
+++ b/cellpack/autopack/loaders/migrate_v1_to_v2.py
@@ -145,7 +145,7 @@ def convert(old_recipe):
     new_recipe["name"] = old_recipe["recipe"]["name"]
     new_recipe["bounding_box"] = old_recipe["options"]["boundingBox"]
     objects_dict = {}
-    #TODO: check if composition structure is correct
+    # TODO: check if composition structure is correct
     composition = {"space": {"regions": {}}}
     if "cytoplasme" in old_recipe:
         outer_most_region_array = []

--- a/cellpack/autopack/loaders/migrate_v1_to_v2.py
+++ b/cellpack/autopack/loaders/migrate_v1_to_v2.py
@@ -121,7 +121,7 @@ def split_ingredient_data(object_key, ingredient_data):
 
 def get_and_store_v2_object(ingredient_key, ingredient_data, region_list, objects_dict):
     if "include" in ingredient_data:
-        ingredient_data = load_file(ingredient_data["include"], cache="recipes")
+        ingredient_data, _ = load_file(ingredient_data["include"], cache="recipes")
     check_required_attributes(ingredient_data)
     converted_ingredient = migrate_ingredient(ingredient_data)
     object_info, composition_info = split_ingredient_data(

--- a/cellpack/autopack/loaders/recipe_loader.py
+++ b/cellpack/autopack/loaders/recipe_loader.py
@@ -194,7 +194,7 @@ class RecipeLoader(object):
                     for region_item in comp_value["regions"][region_name]:
                         if (
                             not region_item.get("name") and "object" in region_item
-                        ):  # if the outer layer of the dict has no name, it's object
+                        ):  # if the outer layer of the dict has no name, it's an object
                             object_copy = copy.deepcopy(region_item["object"])
                             objects[object_copy["name"]] = object_copy
                             if "gradient" in object_copy and isinstance(
@@ -204,13 +204,34 @@ class RecipeLoader(object):
                                     object_copy, objects, gradients
                                 )
         return objects, gradients
+    
+    def _prep_recipe_from_firebase(self, db_recipe_data, obj_dict, grad_dict):
+        """
+        Prepare recipe data from firebase composition data
+        """
+        revert_recipe_data = {}
+        revert_recipe_data["format_version"] = db_recipe_data["format_version"]
+        revert_recipe_data["version"] = db_recipe_data["version"]
+        revert_recipe_data["name"] = db_recipe_data["name"]
+        revert_recipe_data["bounding_box"] = db_recipe_data["bounding_box"]
+        revert_recipe_data["objects"] = None
+        revert_recipe_data["gradients"] = None
+        revert_recipe_data["composition"] = {"regions":{}}
+        for comp_name, comp_value in db_recipe_data["composition"].items():
+            if "name" in comp_value and comp_value["regions"] is None:
+                for region_name in comp_value["regions"]:
+                    revert_recipe_data["composition"][comp_name] = {"regions":{}}
+
+
+
+        return recipe_data
+
 
     def _read(self):
         new_values, database_name = autopack.load_file(self.file_path, cache="recipes")
         if database_name == "firebase":
             objects, gradients = self._collect_objs_and_grads(new_values["composition"])
-            print("objects", objects)
-            print("gradients", gradients)
+            #TODO form a remote recipe that can be read 
         recipe_data = RecipeLoader.default_values.copy()
         recipe_data = deep_merge(recipe_data, new_values)
         recipe_data["format_version"] = RecipeLoader._sanitize_format_version(

--- a/cellpack/autopack/loaders/recipe_loader.py
+++ b/cellpack/autopack/loaders/recipe_loader.py
@@ -170,7 +170,14 @@ class RecipeLoader(object):
         grad_name = obj_data["gradient"]["name"]
         grad_dict[grad_name] = obj_data["gradient"]
         obj_dict[obj_data["name"]]["gradient"] = grad_name
+        RecipeLoader._remove_name_key(grad_dict[grad_name])
         return obj_dict, grad_dict
+    
+    @staticmethod
+    # TODO: remove or handle other unoriginal keys
+    def _remove_name_key(doc_data):
+        if "name" in doc_data:
+            del doc_data["name"]
 
     def _collect_objs_and_grads(self, comp_data):
         """
@@ -189,6 +196,7 @@ class RecipeLoader(object):
                     objects, gradients = RecipeLoader._get_gradient_data(
                         object_copy, objects, gradients
                     )
+                RecipeLoader._remove_name_key(object_copy)
             if "regions" in comp_value and comp_value["regions"] is not None:
                 for region_name in comp_value["regions"]:
                     for region_item in comp_value["regions"][region_name]:
@@ -203,28 +211,29 @@ class RecipeLoader(object):
                                 objects, gradients = RecipeLoader._get_gradient_data(
                                     object_copy, objects, gradients
                                 )
+                        RecipeLoader._remove_name_key(object_copy)
+        print("objects", objects)
+        print("gradients", gradients)
         return objects, gradients
     
-    def _prep_recipe_from_firebase(self, db_recipe_data, obj_dict, grad_dict):
-        """
-        Prepare recipe data from firebase composition data
-        """
-        revert_recipe_data = {}
-        revert_recipe_data["format_version"] = db_recipe_data["format_version"]
-        revert_recipe_data["version"] = db_recipe_data["version"]
-        revert_recipe_data["name"] = db_recipe_data["name"]
-        revert_recipe_data["bounding_box"] = db_recipe_data["bounding_box"]
-        revert_recipe_data["objects"] = None
-        revert_recipe_data["gradients"] = None
-        revert_recipe_data["composition"] = {"regions":{}}
-        for comp_name, comp_value in db_recipe_data["composition"].items():
-            if "name" in comp_value and comp_value["regions"] is None:
-                for region_name in comp_value["regions"]:
-                    revert_recipe_data["composition"][comp_name] = {"regions":{}}
+    # def _prep_recipe_from_firebase(self, db_recipe_data, obj_dict, grad_dict):
+    #     """
+    #     Compile recipe data from firebase composition data
+    #     """
+    #     revert_recipe_data = {}
+    #     revert_recipe_data["format_version"] = db_recipe_data["format_version"]
+    #     revert_recipe_data["version"] = db_recipe_data["version"]
+    #     revert_recipe_data["name"] = db_recipe_data["name"]
+    #     revert_recipe_data["bounding_box"] = db_recipe_data["bounding_box"]
+    #     revert_recipe_data["objects"] = None
+    #     revert_recipe_data["gradients"] = None
+    #     revert_recipe_data["composition"] = {"regions":{}}
+    #     for comp_name, comp_value in db_recipe_data["composition"].items():
+    #         if "name" in comp_value and comp_value["regions"] is None:
+    #             for region_name in comp_value["regions"]:
+    #                 revert_recipe_data["composition"][comp_name] = {"regions":{}}
 
-
-
-        return recipe_data
+    #     return recipe_data
 
 
     def _read(self):

--- a/cellpack/autopack/loaders/recipe_loader.py
+++ b/cellpack/autopack/loaders/recipe_loader.py
@@ -164,14 +164,14 @@ class RecipeLoader(object):
             raise ValueError(
                 f"{old_recipe['format_version']} is not a format version we support"
             )
-        
-    @staticmethod    
+
+    @staticmethod
     def _get_gradient_data(obj_data, obj_dict, grad_dict):
         grad_name = obj_data["gradient"]["name"]
         grad_dict[grad_name] = obj_data["gradient"]
         obj_dict[obj_data["name"]]["gradient"] = grad_name
         return obj_dict, grad_dict
-        
+
     def _collect_objs_and_grads(self, comp_data):
         """
         Collect all object and gradient info from the downloaded firebase composition data
@@ -183,23 +183,34 @@ class RecipeLoader(object):
             if "object" in comp_value and comp_value["object"] is not None:
                 object_copy = copy.deepcopy(comp_value["object"])
                 objects[object_copy["name"]] = object_copy
-                if "gradient" in object_copy and isinstance(object_copy["gradient"], dict):
-                    objects, gradients = RecipeLoader._get_gradient_data(object_copy, objects, gradients)
+                if "gradient" in object_copy and isinstance(
+                    object_copy["gradient"], dict
+                ):
+                    objects, gradients = RecipeLoader._get_gradient_data(
+                        object_copy, objects, gradients
+                    )
             if "regions" in comp_value and comp_value["regions"] is not None:
                 for region_name in comp_value["regions"]:
                     for region_item in comp_value["regions"][region_name]:
-                        if not region_item.get("name") and "object" in region_item: # if the outer layer of the dict has no name, it's object
+                        if (
+                            not region_item.get("name") and "object" in region_item
+                        ):  # if the outer layer of the dict has no name, it's object
                             object_copy = copy.deepcopy(region_item["object"])
                             objects[object_copy["name"]] = object_copy
-                            if "gradient" in object_copy and isinstance(object_copy["gradient"], dict):
-                                objects, gradients = RecipeLoader._get_gradient_data(object_copy, objects, gradients)
+                            if "gradient" in object_copy and isinstance(
+                                object_copy["gradient"], dict
+                            ):
+                                objects, gradients = RecipeLoader._get_gradient_data(
+                                    object_copy, objects, gradients
+                                )
         return objects, gradients
 
     def _read(self):
-        new_values = autopack.load_file(self.file_path, cache="recipes")
-        objects, gradients = self._collect_objs_and_grads(new_values["composition"])
-        print("objects", objects)
-        print("gradients", gradients)
+        new_values, database_name = autopack.load_file(self.file_path, cache="recipes")
+        if database_name == "firebase":
+            objects, gradients = self._collect_objs_and_grads(new_values["composition"])
+            print("objects", objects)
+            print("gradients", gradients)
         recipe_data = RecipeLoader.default_values.copy()
         recipe_data = deep_merge(recipe_data, new_values)
         recipe_data["format_version"] = RecipeLoader._sanitize_format_version(

--- a/cellpack/autopack/loaders/recipe_loader.py
+++ b/cellpack/autopack/loaders/recipe_loader.py
@@ -165,82 +165,8 @@ class RecipeLoader(object):
                 f"{old_recipe['format_version']} is not a format version we support"
             )
 
-    @staticmethod
-    def _get_gradient_data(obj_data, obj_dict, grad_dict):
-        grad_name = obj_data["gradient"]["name"]
-        grad_dict[grad_name] = obj_data["gradient"]
-        obj_dict[obj_data["name"]]["gradient"] = grad_name
-        RecipeLoader._remove_name_key(grad_dict[grad_name])
-        return obj_dict, grad_dict
-    
-    @staticmethod
-    # TODO: remove or handle other unoriginal keys
-    def _remove_name_key(doc_data):
-        if "name" in doc_data:
-            del doc_data["name"]
-
-    def _collect_objs_and_grads(self, comp_data):
-        """
-        Collect all object and gradient info from the downloaded firebase composition data
-        Return autopack object data dict and gradient data dict with name as key
-        """
-        objects = {}
-        gradients = {}
-        for _, comp_value in comp_data.items():
-            if "object" in comp_value and comp_value["object"] is not None:
-                object_copy = copy.deepcopy(comp_value["object"])
-                objects[object_copy["name"]] = object_copy
-                if "gradient" in object_copy and isinstance(
-                    object_copy["gradient"], dict
-                ):
-                    objects, gradients = RecipeLoader._get_gradient_data(
-                        object_copy, objects, gradients
-                    )
-                RecipeLoader._remove_name_key(object_copy)
-            if "regions" in comp_value and comp_value["regions"] is not None:
-                for region_name in comp_value["regions"]:
-                    for region_item in comp_value["regions"][region_name]:
-                        if (
-                            not region_item.get("name") and "object" in region_item
-                        ):  # if the outer layer of the dict has no name, it's an object
-                            object_copy = copy.deepcopy(region_item["object"])
-                            objects[object_copy["name"]] = object_copy
-                            if "gradient" in object_copy and isinstance(
-                                object_copy["gradient"], dict
-                            ):
-                                objects, gradients = RecipeLoader._get_gradient_data(
-                                    object_copy, objects, gradients
-                                )
-                        RecipeLoader._remove_name_key(object_copy)
-        print("objects", objects)
-        print("gradients", gradients)
-        return objects, gradients
-    
-    # def _prep_recipe_from_firebase(self, db_recipe_data, obj_dict, grad_dict):
-    #     """
-    #     Compile recipe data from firebase composition data
-    #     """
-    #     revert_recipe_data = {}
-    #     revert_recipe_data["format_version"] = db_recipe_data["format_version"]
-    #     revert_recipe_data["version"] = db_recipe_data["version"]
-    #     revert_recipe_data["name"] = db_recipe_data["name"]
-    #     revert_recipe_data["bounding_box"] = db_recipe_data["bounding_box"]
-    #     revert_recipe_data["objects"] = None
-    #     revert_recipe_data["gradients"] = None
-    #     revert_recipe_data["composition"] = {"regions":{}}
-    #     for comp_name, comp_value in db_recipe_data["composition"].items():
-    #         if "name" in comp_value and comp_value["regions"] is None:
-    #             for region_name in comp_value["regions"]:
-    #                 revert_recipe_data["composition"][comp_name] = {"regions":{}}
-
-    #     return recipe_data
-
-
     def _read(self):
-        new_values, database_name = autopack.load_file(self.file_path, cache="recipes")
-        if database_name == "firebase":
-            objects, gradients = self._collect_objs_and_grads(new_values["composition"])
-            #TODO form a remote recipe that can be read 
+        new_values = autopack.load_file(self.file_path, cache="recipes")
         recipe_data = RecipeLoader.default_values.copy()
         recipe_data = deep_merge(recipe_data, new_values)
         recipe_data["format_version"] = RecipeLoader._sanitize_format_version(


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including

To avoid submitting a large PR for downloading recipes to review, I separated the resolve gradient code to this branch from the`run-recipes-from-firebase` branch. This pr could be merged into #170.

In the current open pull request #170, we replace gradient data with a gradient path in objects once the gradient is uploaded. We simply compare the grad paths in db_data and local_data to determine whether the new doc should be written or not. 

However, during the downloading process, we need to get the full gradient data from composition in order to compile the recipe data for packing, and ideally we want to get all reference data (objects, gradients, compositions) in the same loop. 

Solution
========
What I/we did to solve this problem

**Resolve gradient data in objects recursively within compositions without breaking the `should_write` checks** 



## Type of change
Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)


Steps to Verify:
----------------
1. `conda activate autopack`
2. `upload -r [relative-path-to-a-gradient-recipe] -c [your-firebase-cred-path]`



Keyfiles (delete if not relevant):
-----------------------
1. `DBRecipeHandler.py`

