### PR TITLE
Limit flake version to fix linting errors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,8 @@ setup_requirements = [
 ]
 
 test_requirements = [
-    "black>=19.10b0, <=23.0",    
-    "flake8>=3.8.3",
+    "black>=19.10b0, <=23.0",
+    "flake8>=3.8.3, <=6.0.0",
     "flake8-debugger>=3.2.1",
     "mdutils>=1.4.0",
     "pytest>=5.4.3",


### PR DESCRIPTION
Problem
=======
We get previously unraised linting errors in github actions due to updates to how `flake8` handles error reporting.

Solution
========
Limited the `flake8` version in `setup.py` to use older version of error reporting.
