### PR TITLE
Feature/standardize result files

### DIFF
--- a/cellpack/autopack/Analysis.py
+++ b/cellpack/autopack/Analysis.py
@@ -2215,9 +2215,7 @@ class Analysis:
         """
         Packs one seed of a recipe and returns the recipe object
         """
-        seed = seed_list[seed_index]  # int(time())
-        seed_basename = self.env.add_seed_number_to_base_name(seed)
-        self.env.set_result_file_name(seed_basename)
+        seed = seed_list[seed_index]
         # Clear
         if self.afviewer:
             self.afviewer.clearFill("Test_Spheres2D")

--- a/cellpack/autopack/Analysis.py
+++ b/cellpack/autopack/Analysis.py
@@ -2216,10 +2216,8 @@ class Analysis:
         Packs one seed of a recipe and returns the recipe object
         """
         seed = seed_list[seed_index]  # int(time())
-        seed_basename = self.env.add_seed_number_to_base_name(packing_basename, seed)
-        self.env.result_file = str(
-            self.env.out_folder / seed_basename
-        )
+        seed_basename = self.env.add_seed_number_to_base_name(seed)
+        self.env.set_result_file_name(seed_basename)
         # Clear
         if self.afviewer:
             self.afviewer.clearFill("Test_Spheres2D")

--- a/cellpack/autopack/Analysis.py
+++ b/cellpack/autopack/Analysis.py
@@ -2215,9 +2215,10 @@ class Analysis:
         """
         Packs one seed of a recipe and returns the recipe object
         """
-        seed_basename = f"seed_{seed_index}_{packing_basename}"
+        seed = seed_list[seed_index]  # int(time())
+        seed_basename = self.env.add_seed_number_to_base_name(packing_basename, seed)
         self.env.result_file = str(
-            self.env.out_folder / f"results_seed_{seed_index}_{packing_basename}"
+            self.env.out_folder / seed_basename
         )
         # Clear
         if self.afviewer:
@@ -2225,7 +2226,6 @@ class Analysis:
         else:
             self.env.reset()
         self.env.saveResult = True
-        seed = seed_list[seed_index]  # int(time())
         numpy.random.seed(seed)
         self.build_grid()
         two_d = self.env.is_two_d()
@@ -2425,7 +2425,7 @@ class Analysis:
         """
         if seed_list is None:
             seed_list = self.getHaltonUnique(number_of_packings)
-        packing_basename = f"{self.env.name}_{config_name}_{recipe_version}"
+        packing_basename = self.env.base_name
         numpy.savetxt(
             self.env.out_folder / f"seeds_{packing_basename}.txt",
             seed_list,

--- a/cellpack/autopack/Analysis.py
+++ b/cellpack/autopack/Analysis.py
@@ -2200,7 +2200,6 @@ class Analysis:
         seed_index,
         seed_list,
         bounding_box,
-        packing_basename,
         center_distance_dict=None,
         pairwise_distance_dict=None,
         ingredient_position_dict=None,
@@ -2215,6 +2214,7 @@ class Analysis:
         """
         Packs one seed of a recipe and returns the recipe object
         """
+        seed_basename = self.env.add_seed_number_to_base_name(seed_index)
         seed = seed_list[seed_index]
         # Clear
         if self.afviewer:
@@ -2510,7 +2510,6 @@ class Analysis:
                     seed_index=seed_index,
                     seed_list=seed_list,
                     bounding_box=bounding_box,
-                    packing_basename=packing_basename,
                     center_distance_dict=center_distance_dict,
                     pairwise_distance_dict=pairwise_distance_dict,
                     ingredient_position_dict=ingredient_position_dict,

--- a/cellpack/autopack/Environment.py
+++ b/cellpack/autopack/Environment.py
@@ -1920,6 +1920,9 @@ class Environment(CompartmentList):
         return f"{self.base_name}_seed_{seed_number}"
 
     def set_result_file_name(self, seed_basename):
+        """
+        Sets the result file name using the output folder path and a given seed basename
+        """
         self.result_file = str(self.out_folder / f"results_{seed_basename}")
 
     def pack_grid(

--- a/cellpack/autopack/Environment.py
+++ b/cellpack/autopack/Environment.py
@@ -150,9 +150,8 @@ class Environment(CompartmentList):
         # saving/pickle option
         self.saveResult = "out" in config
         self.out_folder = create_output_dir(config["out"], name, config["place_method"])
-        self.result_file = (
-            f"{self.out_folder}/{self.name}_{config['name']}_{self.version}"
-        )
+        self.base_name = f"{self.name}_{config['name']}_{self.version}"
+        self.result_file = f"{self.out_folder}/{self.base_name}"
         self.grid_file_out = (
             f"{self.out_folder}/{self.name}_{config['name']}_{self.version}_grid.dat"
         )
@@ -526,9 +525,6 @@ class Environment(CompartmentList):
         save_grid_logs=False,
         save_result_as_file=False,
     ):
-        self.result_file = (
-            f"{self.out_folder}/{self.name}_{self.config_data['name']}_{self.version}_seed_{seedNum}"
-        )
         self.grid.free_points = free_points[:]
         self.grid.distToClosestSurf = distances[:]
         # should check extension filename for type of saved file
@@ -2061,9 +2057,13 @@ class Environment(CompartmentList):
                     ingr.count = count
                     ingr.left_to_place = count
 
+    @staticmethod
+    def add_seed_number_to_base_name(base_name, seed_number):
+        return f"{base_name}_seed_{seed_number}"
+
     def pack_grid(
         self,
-        seedNum=14,
+        seedNum=0,
         name=None,
         vTestid=3,
         vAnalysis=0,
@@ -2076,6 +2076,8 @@ class Environment(CompartmentList):
         # set periodicity
         autopack.testPeriodicity = self.use_periodicity
         t1 = time()
+        seed_base_name = self.add_seed_number_to_base_name(self.base_name, seedNum)
+        self.result_file = f"{self.out_folder}/{seed_base_name}"
         self.timeUpDistLoopTotal = 0
         self.static = []
         if self.grid is None:

--- a/cellpack/autopack/Environment.py
+++ b/cellpack/autopack/Environment.py
@@ -526,6 +526,9 @@ class Environment(CompartmentList):
         save_grid_logs=False,
         save_result_as_file=False,
     ):
+        self.result_file = (
+            f"{self.out_folder}/{self.name}_{self.config_data['name']}_{self.version}_seed_{seedNum}"
+        )
         self.grid.free_points = free_points[:]
         self.grid.distToClosestSurf = distances[:]
         # should check extension filename for type of saved file

--- a/cellpack/autopack/Environment.py
+++ b/cellpack/autopack/Environment.py
@@ -52,7 +52,6 @@ from random import random, uniform, seed
 from scipy import spatial
 import numpy
 import pickle
-import math
 import json
 from json import encoder
 import logging
@@ -83,7 +82,7 @@ from .ingredient import GrowIngredient, ActinIngredient
 from cellpack.autopack import IOutils
 from .octree import Octree
 from .Gradient import Gradient
-from .transformation import euler_from_matrix, signed_angle_between_vectors
+from .transformation import signed_angle_between_vectors
 
 # backward compatibility with kevin method
 from cellpack.autopack.BaseGrid import BaseGrid as BaseGrid
@@ -542,7 +541,7 @@ class Environment(CompartmentList):
             quaternion=True,
             all_ingr_as_array=all_ingr_as_array,
             compartments=self.compartments,
-        ) 
+        )
 
         self.log.info("time to save result file %d", time() - t0)
         self.log.info("self.compartments In Environment = %d", len(self.compartments))
@@ -1919,11 +1918,9 @@ class Environment(CompartmentList):
 
     def add_seed_number_to_base_name(self, seed_number):
         return f"{self.base_name}_seed_{seed_number}"
-    
+
     def set_result_file_name(self, seed_basename):
-        self.result_file = str(
-            self.out_folder / f"results_{seed_basename}"
-        )
+        self.result_file = str(self.out_folder / f"results_{seed_basename}")
 
     def pack_grid(
         self,

--- a/cellpack/autopack/writers/__init__.py
+++ b/cellpack/autopack/writers/__init__.py
@@ -79,7 +79,7 @@ class Writer(object):
         return vdic
 
     def save_as_simularium(
-        self, env, result_file_path, all_ingr_as_array, compartments
+        self, env, all_ingr_as_array, compartments
     ):
         env.helper.clear()
 
@@ -350,6 +350,6 @@ class Writer(object):
                 transpose=transpose,
             )
         elif output_format == "simularium":
-            self.save_as_simularium(env, setupfile, all_ingr_as_array, compartments)
+            self.save_as_simularium(env, all_ingr_as_array, compartments)
         else:
             print("format output " + output_format + " not recognized (json,python)")

--- a/cellpack/autopack/writers/__init__.py
+++ b/cellpack/autopack/writers/__init__.py
@@ -172,7 +172,6 @@ class Writer(object):
                 env.helper.add_grid_data_to_scene(
                     f"{gradient.name}-weights", grid_positions, gradient.weight
                 )
-        # TODO: maybe use f"{env.out_folder}/results_{env.base_name}" instead of f"{env.result_file}_results"
         env.helper.writeToFile(env.result_file, env.boundingBox, env.name, env.version)
 
     def save_Mixed_asJson(

--- a/cellpack/autopack/writers/__init__.py
+++ b/cellpack/autopack/writers/__init__.py
@@ -9,7 +9,20 @@ import numpy
 from collections import OrderedDict
 
 from cellpack import autopack
+from cellpack.autopack.ingredient.grow import ActinIngredient, GrowIngredient
+import cellpack.autopack.transformation as tr
 
+def updatePositionsRadii(ingr):
+    toupdate = {"positions": []}
+    toupdate["radii"] = []
+    if getattr(ingr, "positions", None) is not None:
+        nLOD = len(ingr.positions)
+        for i in range(nLOD):
+            toupdate["positions"].append(
+                {"coords": numpy.array(ingr.positions[i]).flatten().tolist()}
+            )
+            toupdate["radii"].append({"radii": ingr.radii[i]})
+    return toupdate
 
 class IOingredientTool(object):
     # parser that can return an ingredient
@@ -35,6 +48,64 @@ class IOingredientTool(object):
             f = open(filename + ".py", "w")
             f.write(ingrnode)
             f.close()
+
+
+    def ingrJsonNode(self, ingr, result=False, kwds=None, transpose=False):
+        # force position instead of sphereFile
+        ingdic = OrderedDict()
+        if kwds is None:
+            kwds = ingr.KWDS
+        for k in kwds:
+            v = getattr(ingr, str(k))
+            #            if hasattr(v,"tolist"):
+            #                v=v.tolist()
+            #            ingdic[k] = v
+            if v is not None:
+                ingdic.update(Writer.setValueToJsonNode(v, str(k)))
+        # if sphereTree file present should not use the pos-radii keyword
+        # if ingr.sphereFile is not None and not result:
+        # remove the position and radii key
+        #    ingdic.pop("positions", None)
+        #    ingdic.pop("radii", None)
+        # update the positions and radii to new format
+        toupdate = updatePositionsRadii(ingr)
+        ingdic.update(toupdate)
+        if numpy.sum(ingr.offset) != 0.0:
+            if "transform" not in ingr.source:
+                ingr.source["transform"] = {"offset": ingr.offset}
+            else:
+                ingr.source["transform"]["offset"] = ingr.offset
+
+        # reslt ?s
+        if result:
+            ingdic["results"] = []
+            for r in ingr.results:
+                # position
+                if hasattr(r[0], "tolist"):
+                    r[0] = r[0].tolist()
+                # rotation
+                if hasattr(r[1], "tolist"):
+                    r[1] = r[1].tolist()
+                R = numpy.array(r[1]).tolist()  # this will not work with cellvIEW?
+                if transpose:
+                    R = (
+                        numpy.array(r[1]).transpose().tolist()
+                    )  # this will not work with cellvIEW?
+                # transpose ?
+                if self.use_quaternion:
+                    R = tr.quaternion_from_matrix(R).tolist()
+                ingdic["results"].append([r[0], R])
+            if isinstance(ingr, GrowIngredient) or isinstance(ingr, ActinIngredient):
+                ingdic["nbCurve"] = ingr.nbCurve
+                for i in range(ingr.nbCurve):
+                    lp = numpy.array(ingr.listePtLinear[i])
+                    ingr.listePtLinear[i] = lp.tolist()
+                    ingdic["curve" + str(i)] = ingr.listePtLinear[i]
+                #            res=numpy.array(ingdic["results"]).transpose()
+                #            ingdic["results"]=res.tolist()
+        ingdic["name"] = ingr.composition_name
+        return ingdic
+
 
 
 class NumpyArrayEncoder(json.JSONEncoder):
@@ -103,20 +174,14 @@ class Writer(object):
                 env.helper.add_grid_data_to_scene(
                     f"{gradient.name}-weights", grid_positions, gradient.weight
                 )
-
-        # env.helper.writeToFile(
-        #     f"{result_file_path}_results", env.boundingBox, env.name, env.version
-        # )
-
         # TODO: maybe use f"{env.out_folder}/results_{env.base_name}" instead of f"{env.result_file}_results"
         env.helper.writeToFile(
-            f"{env.result_file}_results", env.boundingBox, env.name, env.version
+            env.result_file, env.boundingBox, env.name, env.version
         )
 
     def save_Mixed_asJson(
         self,
         env,
-        setupfile,
         useXref=True,
         kwds=None,
         result=False,
@@ -132,14 +197,14 @@ class Writer(object):
         """
         io_ingr = IOingredientTool(env=env)
         io_ingr.use_quaternion = quaternion
-        env.setupfile = setupfile  # +".json"provide the server?
+        file_name = f"{env.result_file}.json"
         # the output path for this recipes files
-        if env.setupfile.find("http") != -1 or env.setupfile.find("ftp") != -1:
+        if file_name.find("http") != -1 or file_name.find("ftp") != -1:
             pathout = os.path.dirname(
-                os.path.abspath(autopack.retrieveFile(env.setupfile))
+                os.path.abspath(autopack.retrieveFile(file_name))
             )
         else:
-            pathout = os.path.dirname(os.path.abspath(env.setupfile))
+            pathout = os.path.dirname(os.path.abspath(file_name))
         if env.version is None:
             env.version = "1.0"
         env.jsondic = OrderedDict(
@@ -148,8 +213,6 @@ class Writer(object):
         if env.custom_paths:
             # this was the used path at loading time
             env.jsondic["recipe"]["paths"] = env.custom_paths
-        if result:
-            env.jsondic["recipe"]["setupfile"] = env.setupfile
         if packing_options:
             env.jsondic["options"] = {}
             for k in env.OPTIONS:
@@ -296,7 +359,7 @@ class Writer(object):
                         env.jsondic["compartments"][str(o.name)]["interior"][
                             "ingredients"
                         ][ingr.composition_name]["name"] = ingr.composition_name
-        with open(setupfile, "w") as fp:  # doesnt work with symbol link ?
+        with open(file_name, "w") as fp:  # doesnt work with symbol link ?
             if indent:
                 json.dump(
                     env.jsondic,
@@ -324,7 +387,6 @@ class Writer(object):
     def save(
         self,
         env,
-        setupfile,
         kwds=None,
         result=False,
         grid=False,
@@ -339,7 +401,6 @@ class Writer(object):
         if output_format == "json":
             self.save_Mixed_asJson(
                 env,
-                setupfile,
                 useXref=False,
                 kwds=kwds,
                 result=result,

--- a/cellpack/autopack/writers/__init__.py
+++ b/cellpack/autopack/writers/__init__.py
@@ -104,8 +104,13 @@ class Writer(object):
                     f"{gradient.name}-weights", grid_positions, gradient.weight
                 )
 
+        # env.helper.writeToFile(
+        #     f"{result_file_path}_results", env.boundingBox, env.name, env.version
+        # )
+
+        # TODO: maybe use f"{env.out_folder}/results_{env.base_name}" instead of f"{env.result_file}_results"
         env.helper.writeToFile(
-            f"{result_file_path}_results", env.boundingBox, env.name, env.version
+            f"{env.result_file}_results", env.boundingBox, env.name, env.version
         )
 
     def save_Mixed_asJson(

--- a/cellpack/autopack/writers/__init__.py
+++ b/cellpack/autopack/writers/__init__.py
@@ -12,6 +12,7 @@ from cellpack import autopack
 from cellpack.autopack.ingredient.grow import ActinIngredient, GrowIngredient
 import cellpack.autopack.transformation as tr
 
+
 def updatePositionsRadii(ingr):
     toupdate = {"positions": []}
     toupdate["radii"] = []
@@ -23,6 +24,7 @@ def updatePositionsRadii(ingr):
             )
             toupdate["radii"].append({"radii": ingr.radii[i]})
     return toupdate
+
 
 class IOingredientTool(object):
     # parser that can return an ingredient
@@ -48,7 +50,6 @@ class IOingredientTool(object):
             f = open(filename + ".py", "w")
             f.write(ingrnode)
             f.close()
-
 
     def ingrJsonNode(self, ingr, result=False, kwds=None, transpose=False):
         # force position instead of sphereFile
@@ -107,7 +108,6 @@ class IOingredientTool(object):
         return ingdic
 
 
-
 class NumpyArrayEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, numpy.ndarray):
@@ -149,9 +149,7 @@ class Writer(object):
         vdic[attrname] = value
         return vdic
 
-    def save_as_simularium(
-        self, env, all_ingr_as_array, compartments
-    ):
+    def save_as_simularium(self, env, all_ingr_as_array, compartments):
         env.helper.clear()
 
         grid_positions = env.grid.masterGridPositions if env.show_grid_spheres else None
@@ -175,9 +173,7 @@ class Writer(object):
                     f"{gradient.name}-weights", grid_positions, gradient.weight
                 )
         # TODO: maybe use f"{env.out_folder}/results_{env.base_name}" instead of f"{env.result_file}_results"
-        env.helper.writeToFile(
-            env.result_file, env.boundingBox, env.name, env.version
-        )
+        env.helper.writeToFile(env.result_file, env.boundingBox, env.name, env.version)
 
     def save_Mixed_asJson(
         self,
@@ -200,9 +196,7 @@ class Writer(object):
         file_name = f"{env.result_file}.json"
         # the output path for this recipes files
         if file_name.find("http") != -1 or file_name.find("ftp") != -1:
-            pathout = os.path.dirname(
-                os.path.abspath(autopack.retrieveFile(file_name))
-            )
+            pathout = os.path.dirname(os.path.abspath(autopack.retrieveFile(file_name)))
         else:
             pathout = os.path.dirname(os.path.abspath(file_name))
         if env.version is None:


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
closes #180 

Solution
========
What I/we did to solve this problem
- the result file name always includes the seed number, regardless of the `save_analyze_result` setting in the config file
- removed the vAnalysis code from `Environment` as its functionality has now been integrated into `Analysis` 
- streamlined arguments in `save_as_simularium` and `save_as_json` -- removed `setupfile` and get file path from `env` instead
- refactored `updatePositionsRadii` and `ingrJsonNode`  into `Writers` from `IOutils`

with @mogres @meganrm 

## Type of change
Please delete options that are not relevant.
* New feature (non-breaking change which adds functionality)


Steps to Verify:
----------------
1. pack a recipe with `save_analyze_result` turned on and off in the config file

Screenshots (optional):
-----------------------
the result file path and name with or without `save_analyze_result` turned on:

<img width="1044" alt="Screenshot 2023-08-16 at 3 51 34 PM" src="https://github.com/mesoscope/cellpack/assets/91452427/54d1918c-12e3-4f02-be13-979f77bac1b9">

<img width="797" alt="Screenshot 2023-08-18 at 10 10 13 AM" src="https://github.com/mesoscope/cellpack/assets/91452427/2469c6f0-6e4e-4d8b-848e-681451d928b2">



