### PR TITLE
Fix wrong partner list iteration

### DIFF
--- a/cellpack/autopack/Environment.py
+++ b/cellpack/autopack/Environment.py
@@ -389,7 +389,7 @@ class Environment(CompartmentList):
 
     def set_partners_ingredient(self, ingr):
         if ingr.partners is not None:
-            for partner in ingr.partners.all_partners:
+            for partner in ingr.partners:
                 partner_ingr = self.getIngrFromName(partner.name)
                 partner.set_ingredient(partner_ingr)
         if ingr.type == "Grow":


### PR DESCRIPTION
Fixes error running pack command from README: 


 File "/home/user/miniconda3/envs/autopack/lib/python3.9/site-packages/cellpack-1.0.3-py3.9.egg/cellpack/autopack/Environment.py", line 395, in set_partners_ingredient
    for partner in ingr.partners.all_partners:
AttributeError: 'list' object has no attribute 'all_partners'