### PR TITLE
Fix gradient inversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,6 @@ cellpack/tests/outputs/
 # data
 data/
 **/converted/*
+
+# credentials
+.creds

--- a/cellpack/autopack/Gradient.py
+++ b/cellpack/autopack/Gradient.py
@@ -207,14 +207,16 @@ class Gradient:
 
         self.scaled_distances = self.get_normalized_values(self.distances)
 
-        if self.invert == "distance":
-            self.scaled_distances = 1.0 - self.scaled_distances
-
-        if (max(self.scaled_distances) > 1.0) or (min(self.scaled_distances) < 0.0):
+        if (numpy.nanmax(self.scaled_distances) > 1.0) or (
+            numpy.nanmin(self.scaled_distances) < 0.0
+        ):
             raise ValueError(
                 "CHECK CALCULATED DISTANCES",
                 f"Max: {max(self.scaled_distances)}, Min: {min(self.scaled_distances)}",
             )
+
+        if self.invert == "distance":
+            self.scaled_distances = 1.0 - self.scaled_distances
         if self.weight_mode == "linear":
             self.weight = 1.0 - self.scaled_distances
         elif self.weight_mode == "square":
@@ -231,6 +233,12 @@ class Gradient:
             )
         # normalize the weight
         self.weight = self.get_normalized_values(self.weight)
+
+        if (numpy.nanmax(self.weight) > 1.0) or (numpy.nanmin(self.weight) < 0.0):
+            raise ValueError(
+                "CHECK CALCULATED WEIGHTS",
+                f"Max: {max(self.weight)}, Min: {min(self.weight)}",
+            )
 
         self.weight[numpy.isnan(self.weight)] = 0
 

--- a/cellpack/autopack/Gradient.py
+++ b/cellpack/autopack/Gradient.py
@@ -212,8 +212,6 @@ class Gradient:
                 "CHECK CALCULATED DISTANCES",
                 f"Max: {max(self.scaled_distances)}, Min: {min(self.scaled_distances)}",
             )
-        if self.invert:
-            self.scaled_distances = 1.0 - self.scaled_distances
         if self.weight_mode == "linear":
             self.weight = 1.0 - self.scaled_distances
         elif self.weight_mode == "square":
@@ -232,6 +230,9 @@ class Gradient:
         self.weight = self.get_normalized_values(self.weight)
 
         self.weight[numpy.isnan(self.weight)] = 0
+
+        if self.invert:
+            self.weight = 1.0 - self.weight
 
         # TODO: talk to Ludo about calculating gaussian weights
 

--- a/cellpack/autopack/Gradient.py
+++ b/cellpack/autopack/Gradient.py
@@ -207,6 +207,9 @@ class Gradient:
 
         self.scaled_distances = self.get_normalized_values(self.distances)
 
+        if self.invert == "distance":
+            self.scaled_distances = 1.0 - self.scaled_distances
+
         if (max(self.scaled_distances) > 1.0) or (min(self.scaled_distances) < 0.0):
             raise ValueError(
                 "CHECK CALCULATED DISTANCES",
@@ -231,7 +234,7 @@ class Gradient:
 
         self.weight[numpy.isnan(self.weight)] = 0
 
-        if self.invert:
+        if self.invert == "weight":
             self.weight = 1.0 - self.weight
 
         # TODO: talk to Ludo about calculating gaussian weights

--- a/cellpack/autopack/interface_objects/default_values.py
+++ b/cellpack/autopack/interface_objects/default_values.py
@@ -9,7 +9,7 @@ DEFAULT_GRADIENT_MODE_SETTINGS = {
     "pick_mode": "linear",
     "description": "Linear gradient in the X direction",
     "reversed": False,  # is the direction of the vector reversed?
-    "invert": False, # is the gradient inverted? (this does weights = 1 - weights)
+    "invert": False,  # is the gradient inverted? (this does weights = 1 - weights)
     "mode_settings": {},
     "weight_mode_settings": {},
 }

--- a/cellpack/autopack/interface_objects/default_values.py
+++ b/cellpack/autopack/interface_objects/default_values.py
@@ -9,7 +9,7 @@ DEFAULT_GRADIENT_MODE_SETTINGS = {
     "pick_mode": "linear",
     "description": "Linear gradient in the X direction",
     "reversed": False,  # is the direction of the vector reversed?
-    "invert": False,  # is the gradient inverted? (this does weights = 1 - weights)
+    "invert": None,  # options: "weight", "distance"
     "mode_settings": {},
     "weight_mode_settings": {},
 }

--- a/cellpack/autopack/interface_objects/default_values.py
+++ b/cellpack/autopack/interface_objects/default_values.py
@@ -8,8 +8,8 @@ DEFAULT_GRADIENT_MODE_SETTINGS = {
     "weight_mode": "linear",
     "pick_mode": "linear",
     "description": "Linear gradient in the X direction",
-    "reversed": False,
-    "invert": False,
+    "reversed": False,  # is the direction of the vector reversed?
+    "invert": False, # is the gradient inverted? (this does weights = 1 - weights)
     "mode_settings": {},
     "weight_mode_settings": {},
 }

--- a/cellpack/autopack/interface_objects/gradient_data.py
+++ b/cellpack/autopack/interface_objects/gradient_data.py
@@ -60,6 +60,15 @@ class ModeOptions(MetaEnum):
     scale_distance_between = "scale_distance_between"
 
 
+class InvertOptions(MetaEnum):
+    """
+    All available options for individual invert modes
+    """
+
+    weight = "weight"
+    distance = "distance"
+
+
 class WeightModeOptions(MetaEnum):
     """
     All available options for individual weight modes
@@ -118,6 +127,7 @@ class GradientData:
         self.validate_weight_mode_settings(
             gradient_data["weight_mode"], gradient_data.get("weight_mode_settings")
         )
+        self.validate_invert_settings(gradient_data["invert"])
 
     def validate_mode_settings(self, mode_name, mode_settings_dict):
         required_options = REQUIRED_MODE_OPTIONS.get(mode_name)
@@ -150,6 +160,16 @@ class GradientData:
                 raise ValueError(
                     f"Missing required weight mode setting {option} for {weight_mode_name}"
                 )
+
+    def validate_invert_settings(
+        self,
+        invert_option,
+    ):
+        if not invert_option:
+            return
+
+        if not InvertOptions.is_member(invert_option):
+            raise ValueError(f"Invalid gradient invert option: {invert_option}")
 
     def set_mode_properties(self, gradient_data):
         if not gradient_data.get("mode_settings"):

--- a/cellpack/bin/pack.py
+++ b/cellpack/bin/pack.py
@@ -29,6 +29,8 @@ def pack(recipe, config_path=None, analysis_config_path=None):
 
     :return: void
     """
+    log.info(f"Running in {__file__}")
+
     packing_config_data = ConfigLoader(config_path).config
     recipe_data = RecipeLoader(
         recipe, packing_config_data["save_converted_recipe"]

--- a/cellpack/tests/recipes/v2/test_mesh_image_gradient.json
+++ b/cellpack/tests/recipes/v2/test_mesh_image_gradient.json
@@ -20,7 +20,7 @@
             "weight_mode": "exponential",
             "pick_mode": "rnd",
             "mode": "vector",
-            "invert": true,
+            "invert": "weight",
             "mode_settings": {
                 "direction": [
                     0.707,
@@ -34,7 +34,7 @@
                 ]
             },
             "weight_mode_settings": {
-                "decay_length": 0.05
+                "decay_length": 0.3
             }
         }
     },    
@@ -61,7 +61,7 @@
                 1,
                 1
             ],
-            "radius": 0.1,
+            "radius": 1,
             "packing_mode": "gradient",
             "gradient": "planar_gradient"
         }

--- a/cellpack/tests/test_gradient_data.py
+++ b/cellpack/tests/test_gradient_data.py
@@ -22,7 +22,7 @@ from cellpack.autopack.interface_objects import GradientData
                 "pick_mode": "linear",
                 "description": "Linear gradient in the X direction",
                 "reversed": False,
-                "invert": False,
+                "invert": None,
                 "name": "gradient_name",
                 "mode_settings": {
                     "direction": [1, 0, 0],
@@ -49,7 +49,7 @@ from cellpack.autopack.interface_objects import GradientData
                 "pick_mode": "linear",
                 "description": "Square gradient in the radial direction",
                 "reversed": False,
-                "invert": False,
+                "invert": None,
                 "name": "gradient_name",
                 "mode_settings": {
                     "center": [0, 0, 0],
@@ -74,7 +74,7 @@ from cellpack.autopack.interface_objects import GradientData
                 "pick_mode": "linear",
                 "description": "Cubic gradient in the Y direction",
                 "reversed": True,
-                "invert": False,
+                "invert": None,
                 "name": "gradient_name",
                 "mode_settings": {"direction": [0, -1, 0]},
                 "weight_mode_settings": {},
@@ -101,7 +101,7 @@ from cellpack.autopack.interface_objects import GradientData
                 "description": "power law gradient from surface",
                 "pick_mode": "linear",
                 "reversed": False,
-                "invert": False,
+                "invert": None,
                 "mode_settings": {
                     "object": "object_name",
                 },


### PR DESCRIPTION
Problem
=======
Gradient inversion used distances instead of weights. This could result in unexpected inversion.

Solution
========
The type of inversion can be specified as an option now. `invert: "distance"` inverts the scaled distances and `invert: "weight"` inverts the weights after calculation.

## Type of change
* Bug fix (non-breaking change which fixes an issue)

Change summary:
---------------
* add option to specify inversion using weights or distances
* add default values
* update test recipes to visualize inversion
* add credentials file to gitignore

Steps to Verify:
----------------
1. `pack -r cellpack/tests/recipes/v2/test_mesh_image_gradient.json -c cellpack/tests/packing-configs/test_mesh_config.json`
2. Change `invert: "weight"` to `invert: "distance"` to visualize alternative inversion.

Screenshots:
-----------------------
Inverting distances: 
![image](https://github.com/mesoscope/cellpack/assets/101426188/59f24200-72ff-4090-bebf-fe8370c19558)

Inverting weights:
![image](https://github.com/mesoscope/cellpack/assets/101426188/0caa92b2-7d26-4f42-8144-ba93c4f6ecd1)

Keyfiles:
-----------------------
1. Gradient.py
