### PR TITLE
fix/S3 uploads and new browser tabs handling 

### DIFF
--- a/cellpack/autopack/writers/__init__.py
+++ b/cellpack/autopack/writers/__init__.py
@@ -187,7 +187,7 @@ class Writer(object):
         )
         upload_results = env.config_data.get("upload_results", False)
         number_of_packings = env.config_data.get("number_of_packings", 1)
-        if (upload_results or number_of_packings == 1):
+        if upload_results or number_of_packings == 1:
             autopack.helper.post_and_open_file(file_name)
 
     def save_Mixed_asJson(

--- a/cellpack/autopack/writers/__init__.py
+++ b/cellpack/autopack/writers/__init__.py
@@ -185,9 +185,9 @@ class Writer(object):
         file_name = env.helper.writeToFile(
             env.result_file, env.boundingBox, env.name, env.version
         )
-        if env.config_data.get(
-            "upload_results", env.config_data.get("number_of_packings", 1) <= 1
-        ):
+        upload_results = env.config_data.get("upload_results", False)
+        number_of_packings = env.config_data.get("number_of_packings", 1)
+        if (upload_results or number_of_packings == 1):
             autopack.helper.post_and_open_file(file_name)
 
     def save_Mixed_asJson(


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
our current conditional statement ` if env.config_data.get("upload_results", env.config_data.get("number_of_packings", 1) <= 1):` on `main` prioritizes checking `upload_results` with its default value set to `False`. So the check will be skipped if `upload_results` is not explicitly set to `True` in the config file

Solution
========
What I/we did to solve this problem
changed the if-statement to evaluate `upload_results` and `number_of_packings` individually

with @meganrm 

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)
