### PR TITLE
read grid file path from recipe if provided

### DIFF
--- a/cellpack/autopack/Environment.py
+++ b/cellpack/autopack/Environment.py
@@ -156,6 +156,8 @@ class Environment(CompartmentList):
         self.grid_file_out = (
             f"{self.out_folder}/{self.name}_{config['name']}_{self.version}_grid.dat"
         )
+        if recipe.get("grid_file_path") is not None:
+            self.grid_file_out = recipe["grid_file_path"]
 
         should_load_grid_file = (
             os.path.isfile(self.grid_file_out) and self.load_from_grid_file

--- a/cellpack/autopack/Environment.py
+++ b/cellpack/autopack/Environment.py
@@ -157,7 +157,8 @@ class Environment(CompartmentList):
             f"{self.out_folder}/{self.name}_{config['name']}_{self.version}_grid.dat"
         )
         if recipe.get("grid_file_path") is not None:
-            self.grid_file_out = recipe["grid_file_path"]
+            if os.path.isfile(recipe["grid_file_path"]):
+                self.grid_file_out = recipe["grid_file_path"]
 
         should_load_grid_file = (
             os.path.isfile(self.grid_file_out) and self.load_from_grid_file


### PR DESCRIPTION
Problem
=======
For complicated meshes, the grid file takes a long time to create. There is currently no way to reuse grids for the same compartments without renaming the grid file.

Closes #204 

Solution
========
I added a check for `"grid_file_path"` in the recipe which loads from the specified grid file if it is present.

## Type of change
* New feature (non-breaking change which adds functionality)

Change summary:
---------------
* read grid file from recipe if provided and if file exists

Steps to Verify:
----------------
1. Rename previously created grid file for a recipe
2. Add an option in the recipe with `"grid_file_path": PATH_TO_RENAMED_GRID_FILE`
3. Use a config with `"load_from_grid_file": true`

cellPACK should load the grid from the specified path instead of the default

Keyfiles:
-----------------------
1. Environment.py