### PR TITLE
Feature/save metadata to firebase

### DIFF
--- a/cellpack/autopack/DBRecipeHandler.py
+++ b/cellpack/autopack/DBRecipeHandler.py
@@ -574,6 +574,19 @@ class DBUploader(object):
         key = self._get_recipe_id(recipe_to_save)
         self.upload_data("recipes", recipe_to_save, key)
 
+    def upload_result_metadata(self, file_name, url):
+        """
+        Upload the metadata of the result file to the database.
+        """
+        if self.db:
+            username = self.db.get_username()
+            timestamp = self.db.create_timestamp()
+            self.db.update_or_create(
+                "results",
+                file_name,
+                {"user": username, "timestamp": timestamp, "url": url.split("?")[0]},
+            )
+
 
 class DBRecipeLoader(object):
     """

--- a/cellpack/autopack/FirebaseHandler.py
+++ b/cellpack/autopack/FirebaseHandler.py
@@ -1,6 +1,7 @@
-import firebase_admin
 import ast
+import firebase_admin
 from firebase_admin import credentials, firestore
+from google.cloud.exceptions import NotFound
 from cellpack.autopack.loaders.utils import read_json_file, write_json_file
 
 
@@ -9,17 +10,133 @@ class FirebaseHandler(object):
     Retrieve data and perform common tasks when working with firebase.
     """
 
+    # use class attributes to maintain a consistent state across all instances
+    _initialized = False
+    _db = None
+
     def __init__(self):
-        cred_path = FirebaseHandler.get_creds()
-        login = credentials.Certificate(cred_path)
-        firebase_admin.initialize_app(login)
-        self.db = firestore.client()
+        # check if firebase is already initialized
+        if not FirebaseHandler._initialized:
+            cred_path = FirebaseHandler.get_creds()
+            login = credentials.Certificate(cred_path)
+            firebase_admin.initialize_app(login)
+            FirebaseHandler._initialized = True
+            FirebaseHandler._db = firestore.client()
+
+        self.db = FirebaseHandler._db
         self.name = "firebase"
 
+    # common utility methods
     @staticmethod
     def doc_to_dict(doc):
         return doc.to_dict()
 
+    @staticmethod
+    def doc_id(doc):
+        return doc.id
+
+    @staticmethod
+    def create_path(collection, doc_id):
+        return f"firebase:{collection}/{doc_id}"
+
+    @staticmethod
+    def create_timestamp():
+        return firestore.SERVER_TIMESTAMP
+
+    @staticmethod
+    def get_path_from_ref(doc):
+        return doc.path
+
+    @staticmethod
+    def get_collection_id_from_path(path):
+        # path example = firebase:composition/uid_1
+        components = path.split(":")[1].split("/")
+        collection = components[0]
+        id = components[1]
+        return collection, id
+
+    # Create methods
+    def set_doc(self, collection, id, data):
+        doc, doc_ref = self.get_doc_by_id(collection, id)
+        if not doc:
+            doc_ref = self.db.collection(collection).document(id)
+            doc_ref.set(data)
+            print(f"successfully uploaded to path: {doc_ref.path}")
+            return doc_ref
+        else:
+            print(
+                f"ERROR: {doc_ref.path} already exists. If uploading new data, provide a unique recipe name."
+            )
+            return
+
+    def upload_doc(self, collection, data):
+        return self.db.collection(collection).add(data)
+
+    # Read methods
+    @staticmethod
+    def get_creds():
+        creds = read_json_file("./.creds")
+        if creds is None or "firebase" not in creds:
+            creds = FirebaseHandler.write_creds_path()
+        return creds["firebase"]
+
+    @staticmethod
+    def get_username():
+        creds = read_json_file("./.creds")
+        try:
+            return creds["username"]
+        except KeyError:
+            raise ValueError("No username found in .creds file")
+
+    def db_name(self):
+        return self.name
+
+    def get_doc_by_name(self, collection, name):
+        db = self.db
+        data_ref = db.collection(collection)
+        docs = data_ref.where("name", "==", name).get()  # docs is an array
+        return docs
+
+    def get_doc_by_id(self, collection, id):
+        # `doc` is a DocumentSnapshot object
+        # `doc_ref` is a DocumentReference object to perform operations on the doc
+        doc_ref = self.db.collection(collection).document(id)
+        doc = doc_ref.get()
+        if doc.exists:
+            return doc.to_dict(), doc_ref
+        else:
+            return None, None
+
+    def get_doc_by_ref(self, path):
+        collection, id = FirebaseHandler.get_collection_id_from_path(path)
+        return self.get_doc_by_id(collection, id)
+
+    # Update methods
+    def update_doc(self, collection, id, data):
+        doc_ref = self.db.collection(collection).document(id)
+        doc_ref.update(data)
+        print(f"successfully updated to path: {doc_ref.path}")
+        return doc_ref
+
+    @staticmethod
+    def update_reference_on_doc(doc_ref, index, new_item_ref):
+        doc_ref.update({index: new_item_ref})
+
+    @staticmethod
+    def update_elements_in_array(doc_ref, index, new_item_ref, remove_item):
+        doc_ref.update({index: firestore.ArrayRemove([remove_item])})
+        doc_ref.update({index: firestore.ArrayUnion([new_item_ref])})
+
+    def update_or_create(self, collection, id, data):
+        """
+        If the input id exists, update the doc. If not, create a new file.
+        """
+        try:
+            self.update_doc(collection, id, data)
+        except NotFound:
+            self.set_doc(collection, id, data)
+
+    # other utils
     @staticmethod
     def write_creds_path():
         path = ast.literal_eval(input("provide path to firebase credentials: "))
@@ -36,45 +153,6 @@ class FirebaseHandler(object):
         return firebase_cred
 
     @staticmethod
-    def get_creds():
-        creds = read_json_file("./.creds")
-        if creds is None or "firebase" not in creds:
-            creds = FirebaseHandler.write_creds_path()
-        return creds["firebase"]
-
-    def db_name(self):
-        return self.name
-
-    @staticmethod
-    def doc_id(doc):
-        return doc.id
-
-    @staticmethod
-    def create_path(collection, doc_id):
-        return f"firebase:{collection}/{doc_id}"
-
-    @staticmethod
-    def get_path_from_ref(doc):
-        return doc.path
-
-    @staticmethod
-    def get_collection_id_from_path(path):
-        # path example = firebase:composition/uid_1
-        components = path.split(":")[1].split("/")
-        collection = components[0]
-        id = components[1]
-        return collection, id
-
-    @staticmethod
-    def update_reference_on_doc(doc_ref, index, new_item_ref):
-        doc_ref.update({index: new_item_ref})
-
-    @staticmethod
-    def update_elements_in_array(doc_ref, index, new_item_ref, remove_item):
-        doc_ref.update({index: firestore.ArrayRemove([remove_item])})
-        doc_ref.update({index: firestore.ArrayUnion([new_item_ref])})
-
-    @staticmethod
     def is_reference(path):
         if not isinstance(path, str):
             return False
@@ -83,42 +161,6 @@ class FirebaseHandler(object):
         if path.startswith("firebase:"):
             return True
         return False
-
-    def get_doc_by_name(self, collection, name):
-        db = self.db
-        data_ref = db.collection(collection)
-        docs = data_ref.where("name", "==", name).get()  # docs is an array
-        return docs
-
-    # `doc` is a DocumentSnapshot object
-    # `doc_ref` is a DocumentReference object to perform operations on the doc
-    def get_doc_by_id(self, collection, id):
-        doc_ref = self.db.collection(collection).document(id)
-        doc = doc_ref.get()
-        if doc.exists:
-            return doc.to_dict(), doc_ref
-        else:
-            return None, None
-
-    def get_doc_by_ref(self, path):
-        collection, id = FirebaseHandler.get_collection_id_from_path(path)
-        return self.get_doc_by_id(collection, id)
-
-    def set_doc(self, collection, id, data):
-        doc, doc_ref = self.get_doc_by_id(collection, id)
-        if not doc:
-            doc_ref = self.db.collection(collection).document(id)
-            doc_ref.set(data)
-            print(f"successfully uploaded to path: {doc_ref.path}")
-            return doc_ref
-        else:
-            print(
-                f"ERROR: {doc_ref.path} already exists. If uploading new data, provide a unique recipe name."
-            )
-            return
-
-    def upload_doc(self, collection, data):
-        return self.db.collection(collection).add(data)
 
     @staticmethod
     def is_firebase_obj(obj):

--- a/cellpack/autopack/__init__.py
+++ b/cellpack/autopack/__init__.py
@@ -48,7 +48,6 @@ from collections import OrderedDict
 import ssl
 import json
 from cellpack.autopack.DBRecipeHandler import DBRecipeLoader
-from cellpack.autopack.FirebaseHandler import FirebaseHandler
 from cellpack.autopack.interface_objects.database_ids import DATABASE_IDS
 
 from cellpack.autopack.loaders.utils import read_json_file, write_json_file
@@ -384,9 +383,9 @@ def read_text_file(filename, destination="", cache="collisionTrees", force=None)
 def load_file(filename, destination="", cache="geometries", force=None):
     if is_remote_path(filename):
         database_name, file_path = convert_db_shortname_to_url(filename)
-        # command example: `pack -r firebase:recipes/peroxisomes_surface_gradient_v-nucleus_cube -c examples/packing-configs/peroxisome_packing_config.json`
+        # command example: `pack -r firebase:recipes/[FIREBASE-RECIPE-ID] -c [CONFIG-FILE-PATH]`
         if database_name == "firebase":
-            db = FirebaseHandler()
+            db = DATABASE_IDS.handlers().get(database_name)
             db_handler = DBRecipeLoader(db)
             recipe_id = file_path.split("/")[-1]
             db_doc, _ = db_handler.collect_docs_by_id(

--- a/cellpack/autopack/interface_objects/database_ids.py
+++ b/cellpack/autopack/interface_objects/database_ids.py
@@ -1,10 +1,28 @@
 from .meta_enum import MetaEnum
+from cellpack.autopack.AWSHandler import AWSHandler
+from cellpack.autopack.FirebaseHandler import FirebaseHandler
 
 
 class DATABASE_IDS(MetaEnum):
     FIREBASE = "firebase"
     GITHUB = "github"
+    AWS = "aws"
 
     @classmethod
     def with_colon(cls):
         return [f"{ele}:" for ele in cls.values()]
+
+    @classmethod
+    def handlers(cls):
+        def create_aws_handler(bucket_name, sub_folder_name, region_name):
+            return AWSHandler(
+                bucket_name=bucket_name,
+                sub_folder_name=sub_folder_name,
+                region_name=region_name,
+            )
+
+        handlers_dict = {
+            cls.FIREBASE: FirebaseHandler(),
+            cls.AWS: create_aws_handler,
+        }
+        return handlers_dict

--- a/cellpack/autopack/upy/simularium/simularium_helper.py
+++ b/cellpack/autopack/upy/simularium/simularium_helper.py
@@ -23,7 +23,8 @@ from simulariumio.cellpack import CellpackConverter, HAND_TYPE
 from simulariumio.constants import DISPLAY_TYPE, VIZ_TYPE
 
 from cellpack.autopack.upy import hostHelper
-from cellpack.autopack.AWSHandler import AWSHandler
+from cellpack.autopack.DBRecipeHandler import DBUploader
+from cellpack.autopack.interface_objects.database_ids import DATABASE_IDS
 import collada
 
 
@@ -1387,7 +1388,7 @@ class simulariumHelper(hostHelper.Helper):
         simularium_file = Path(f"{file_name}.simularium")
         url = None
         try:
-            url = simulariumHelper.store_results_to_s3(simularium_file)
+            _, url = simulariumHelper.store_result_file(simularium_file, storage="aws")
         except Exception as e:
             aws_readme_url = "https://github.com/mesoscope/cellpack/blob/feature/main/README.md#aws-s3"
             if isinstance(e, NoCredentialsError):
@@ -1402,14 +1403,23 @@ class simulariumHelper(hostHelper.Helper):
             simulariumHelper.open_in_simularium(url)
 
     @staticmethod
-    def store_results_to_s3(file_path):
-        handler = AWSHandler(
-            bucket_name="cellpack-results",
-            sub_folder_name="simularium/",
-            region_name="us-west-2",
-        )
-        url = handler.save_file(file_path)
-        return url
+    def store_result_file(file_path, storage=None):
+        if storage == "aws":
+            handler = DATABASE_IDS.handlers().get(storage)
+            initialized_handler = handler(
+                bucket_name="cellpack-results",
+                sub_folder_name="simularium/",
+                region_name="us-west-2",
+            )
+        file_name, url = initialized_handler.save_file(file_path)
+        simulariumHelper.store_metadata(file_name, url, db="firebase")
+        return file_name, url
+
+    @staticmethod
+    def store_metadata(file_name, url, db=None):
+        if db == "firebase":
+            db_handler = DBUploader(DATABASE_IDS.handlers().get(db))
+            db_handler.upload_result_metadata(file_name, url)
 
     @staticmethod
     def open_in_simularium(aws_url):


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
closes #194 

Solution
========
What I/we did to solve this problem
- wrote a function to save metadata of aws results files to firebase. The stored metadata includes fields such as "username", "timestamp", "aws_url", with the recipe's unique name being as the key
- handlers are initiated using the DATABASE_IDS enum, ensuring that the DBRecipeHandler remains agnostic 
- rearranged firebase handler and aws handler to
   * ensure they are initialized only once
   * improve readability 

## Type of change
Please delete options that are not relevant.
* New feature (non-breaking change which adds functionality)


Steps to Verify:
----------------
1. pack either local or remote recipes to see if the result files has been uploaded to S3 and saved metadata to firebase

Screenshots (optional):
-----------------------
<img width="1265" alt="Screenshot 2023-10-23 at 1 16 59 PM" src="https://github.com/mesoscope/cellpack/assets/91452427/04e4c513-06b3-4b33-a463-4860317b81c5">
