### PR TITLE
Maintenance/update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ algorithm to pack molecular recipes
 3. `pip install -e .[dev]`
 
 ### Run pack code
-1. example pack recipe : `pack -r examples/recipes/v1/NM_Analysis_FigureB1.0.json -c examples/packing-configs/run.json`
-2. example pack from remote : `pack -r  github:recipes/NM_Analysis_FigureB1.0.json  -c examples/packing-configs/run.json`
+1. example pack v1 recipe : `pack -r examples/recipes/v1/NM_Analysis_FigureB1.0.json -c examples/packing-configs/run.json`
+2. example pack v2 recipe :  `pack -r examples/recipes/v2/nested.json -c examples/packing-configs/run.json`
+3. example pack from remote : `pack -r  github:recipes/NM_Analysis_FigureB1.0.json  -c examples/packing-configs/run.json`
 
 ### Run conversion code 
 * To convert to simularium and view at https://staging.simularium.allencell.org/viewer

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ algorithm to pack molecular recipes
 3. `pip install -e .[dev]`
 
 ### Run pack code
-1. example pack recipe : `pack -r  examples/recipes/v1/NM_Analysis_FigureB1.0.json  -c packing-configs/run.json`
-2. example pack from remote : `pack -r  github:recipes/NM_Analysis_FigureB1.0.json  -c packing-configs/run.json`
+1. example pack recipe : `pack -r examples/recipes/v1/NM_Analysis_FigureB1.0.json -c examples/packing-configs/run.json`
+2. example pack from remote : `pack -r  github:recipes/NM_Analysis_FigureB1.0.json  -c examples/packing-configs/run.json`
 
 ### Run conversion code 
 * To convert to simularium and view at https://staging.simularium.allencell.org/viewer

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ algorithm to pack molecular recipes
 
 ### Run pack code
 1. example pack v1 recipe : `pack -r examples/recipes/v1/NM_Analysis_FigureB1.0.json -c examples/packing-configs/run.json`
-2. example pack v2 recipe :  `pack -r examples/recipes/v2/nested.json -c examples/packing-configs/run.json`
+2. example pack v2 recipe :  `pack -r examples/recipes/v2/one_sphere.json -c examples/packing-configs/run.json`
 3. example pack from remote : `pack -r  github:recipes/NM_Analysis_FigureB1.0.json  -c examples/packing-configs/run.json`
 
 ### Run conversion code 

--- a/cellpack/autopack/upy/simularium/simularium_helper.py
+++ b/cellpack/autopack/upy/simularium/simularium_helper.py
@@ -1389,7 +1389,9 @@ class simulariumHelper(hostHelper.Helper):
         try:
             url = simulariumHelper.store_results_to_s3(simularium_file)
         except Exception as e:
-            aws_readme_url = "https://github.com/mesoscope/cellpack/blob/feature/main/README.md#aws-s3"
+            aws_readme_url = (
+                "https://github.com/mesoscope/cellpack/blob/main/README.md#aws-s3"
+            )
             if isinstance(e, NoCredentialsError):
                 print(
                     f"need to configure your aws account, find instructions here: {aws_readme_url}"


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
In README, the current paths for example pack recipes need to be updated
the current link to README AWS S3 section in `simularium_helper` results in a 404

Solution
========
What I/we did to solve this problem
updated paths and link

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. pack the example recipes in README
2. click the link to README's AWS section in `simularium_helper`


