### PR TITLE
Enable staging Firebase database  

### DIFF
--- a/cellpack/autopack/FirebaseHandler.py
+++ b/cellpack/autopack/FirebaseHandler.py
@@ -38,8 +38,9 @@ class FirebaseHandler(object):
         options = {"1": "dev", "2": "staging"}
         print("Choose database:")
         for key, value in options.items():
-            print(f"{key}: {value}")
+            print(f"[{key}] {value}")
         choice = input("Enter number: ").strip()
+        print(f"Using {options.get(choice, 'dev')} database -------------")
         return options.get(choice, "dev")  # default to dev db
 
     @staticmethod

--- a/cellpack/autopack/FirebaseHandler.py
+++ b/cellpack/autopack/FirebaseHandler.py
@@ -1,6 +1,8 @@
 import ast
+import os
 import firebase_admin
 from firebase_admin import credentials, firestore
+from dotenv import load_dotenv
 from google.cloud.exceptions import NotFound
 from cellpack.autopack.loaders.utils import read_json_file, write_json_file
 
@@ -17,8 +19,12 @@ class FirebaseHandler(object):
     def __init__(self):
         # check if firebase is already initialized
         if not FirebaseHandler._initialized:
-            cred_path = FirebaseHandler.get_creds()
-            login = credentials.Certificate(cred_path)
+            db_choice = FirebaseHandler.which_db()
+            if db_choice == "staging":
+                cred = FirebaseHandler.get_staging_creds()
+            else:
+                cred = FirebaseHandler.get_dev_creds()
+            login = credentials.Certificate(cred)
             firebase_admin.initialize_app(login)
             FirebaseHandler._initialized = True
             FirebaseHandler._db = firestore.client()
@@ -27,6 +33,15 @@ class FirebaseHandler(object):
         self.name = "firebase"
 
     # common utility methods
+    @staticmethod
+    def which_db():
+        options = {"1": "dev", "2": "staging"}
+        print("Choose database:")
+        for key, value in options.items():
+            print(f"{key}: {value}")
+        choice = input("Enter number: ").strip()
+        return options.get(choice, "dev")  # default to dev db
+
     @staticmethod
     def doc_to_dict(doc):
         return doc.to_dict()
@@ -74,11 +89,25 @@ class FirebaseHandler(object):
 
     # Read methods
     @staticmethod
-    def get_creds():
+    def get_dev_creds():
         creds = read_json_file("./.creds")
         if creds is None or "firebase" not in creds:
             creds = FirebaseHandler.write_creds_path()
         return creds["firebase"]
+
+    @staticmethod
+    def get_staging_creds():
+        # use override=True to refresh .env in case software updates affect env variables loading
+        load_dotenv(dotenv_path="./.env", override=True)
+        FIREBASE_TOKEN = os.getenv("FIREBASE_TOKEN")
+        FIREBASE_EMAIL = os.getenv("FIREBASE_EMAIL")
+        return {
+            "type": "service_account",
+            "project_id": "cell-pack-database",
+            "client_email": FIREBASE_EMAIL,
+            "private_key": FIREBASE_TOKEN,
+            "token_uri": "https://oauth2.googleapis.com/token",
+        }
 
     @staticmethod
     def get_username():

--- a/cellpack/autopack/FirebaseHandler.py
+++ b/cellpack/autopack/FirebaseHandler.py
@@ -101,13 +101,12 @@ class FirebaseHandler(object):
         # set override=True to refresh the .env file if softwares or tokens updated
         load_dotenv(dotenv_path="./.env", override=False)
         FIREBASE_TOKEN = os.getenv("FIREBASE_TOKEN")
-        firebase_key = FIREBASE_TOKEN.replace("\\n", "\n")
         FIREBASE_EMAIL = os.getenv("FIREBASE_EMAIL")
         return {
             "type": "service_account",
             "project_id": "cell-pack-database",
             "client_email": FIREBASE_EMAIL,
-            "private_key": firebase_key,
+            "private_key": FIREBASE_TOKEN,
             "token_uri": "https://oauth2.googleapis.com/token",
         }
 

--- a/cellpack/autopack/FirebaseHandler.py
+++ b/cellpack/autopack/FirebaseHandler.py
@@ -98,15 +98,16 @@ class FirebaseHandler(object):
 
     @staticmethod
     def get_staging_creds():
-        # use override=True to refresh .env in case software updates affect env variables loading
-        load_dotenv(dotenv_path="./.env", override=True)
+        # set override=True to refresh the .env file if softwares or tokens updated
+        load_dotenv(dotenv_path="./.env", override=False)
         FIREBASE_TOKEN = os.getenv("FIREBASE_TOKEN")
+        firebase_key = FIREBASE_TOKEN.replace("\\n", "\n")
         FIREBASE_EMAIL = os.getenv("FIREBASE_EMAIL")
         return {
             "type": "service_account",
             "project_id": "cell-pack-database",
             "client_email": FIREBASE_EMAIL,
-            "private_key": FIREBASE_TOKEN,
+            "private_key": firebase_key,
             "token_uri": "https://oauth2.googleapis.com/token",
         }
 

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ requirements = [
     "pymunk>=6.2.0",
     "trimesh>=3.9.34",
     "deepdiff>=5.5.0",
+    "python-dotenv>=1.0.0",
 ]
 
 extra_requirements = {
@@ -103,10 +104,10 @@ setup(
     name="cellpack",
     packages=find_packages(exclude=["tests", "*.tests", "*.tests.*"]),
     package_data={
-        '': [
-            'cellpack/tests/packing-configs/*',
-            'cellpack/tests/recipes/*',
-            'logging.conf'
+        "": [
+            "cellpack/tests/packing-configs/*",
+            "cellpack/tests/recipes/*",
+            "logging.conf",
         ]
     },
     python_requires=">=3.8",


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
#214 

Solution
========
What I/we did to solve this problem
- stored staging firebase database credentials in a `.env` file
    - the `.env` should look like: 
        `FIREBASE_TOKEN=["private_key"]`
        `FIREBASE_EMAIL=["client_email"]`  
- developed functions that allow user to choose from dev or stag db 

Next steps: 
- validate the input path #212 
- handle cases like: no recipe/data found in the selected db. Provide clear error messages

## Type of change
Please delete options that are not relevant.
* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. obtain credentials to put in the `.env` (Ruge will invite @mogres to cellPACK staging db)
2. upload a recipe to staging - `upload -r examples/recipes/v2/one_sphere.json`
3. pack the uploaded recipe - `pack -r firebase:recipes/one_sphere_v_1.0.0 -c examples/packing-configs/run.json`  
4. pack a local recipe and choose a database to save the result file metadata 

Screenshots (optional):
-----------------------
<img width="965" alt="Screenshot 2024-01-04 at 4 28 16 PM" src="https://github.com/mesoscope/cellpack/assets/91452427/b8306eea-10fa-4ecf-8613-f59069c91549">


