### PR TITLE
Fix: prevent duplicate uploads of single packings

### DIFF
--- a/cellpack/autopack/Analysis.py
+++ b/cellpack/autopack/Analysis.py
@@ -2487,7 +2487,8 @@ class Analysis:
         self.writeJSON(ingredient_occurences_file, ingredient_occurence_dict)
         self.writeJSON(ingredient_key_file, ingredient_key_dict)
 
-        Writer().save_as_simularium(self.env, self.seed_to_results)
+        if number_of_packings > 1:
+            Writer().save_as_simularium(self.env, self.seed_to_results)
 
         all_ingredient_positions = self.combine_results_from_seeds(
             ingredient_position_dict


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
When `"save_analyze_result"` is set to `True` in the config file, a single packing recipe will be uploaded twice

What I/we did to solve this problem
In `Analysis.py` at L2490, we made an update to the `doloop` function to call `save_as_simularium` only when `number_of_packings` > 1

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. `pack -r examples/recipes/v2/one_sphere.json -c examples/packing-configs/debug.json `


