### PR TITLE
change extended to true

### DIFF
--- a/cellpack/autopack/Compartment.py
+++ b/cellpack/autopack/Compartment.py
@@ -1367,7 +1367,7 @@ class Compartment(CompartmentList):
 
         off_grid_surface_points = surface_points_in_bounding_box
 
-        ex = False  # True if nbGridPoints == len(idarray) else False
+        ex = True  # True if nbGridPoints == len(idarray) else False
 
         surfacePoints, surfacePointsNormals = self.extendGridArrays(
             nbGridPoints,

--- a/examples/packing-configs/debug.json
+++ b/examples/packing-configs/debug.json
@@ -1,7 +1,7 @@
 {
     "name": "debug",
     "format": "simularium",
-    "inner_grid_method": "raytrace",
+    "inner_grid_method": "trimesh",
     "live_packing": false,
     "ordered_packing": false,
     "out": "out/",

--- a/examples/recipes/v2/nested.json
+++ b/examples/recipes/v2/nested.json
@@ -19,7 +19,6 @@
             "type": "single_sphere",
             "jitter_attempts": 10,
             "packing_mode": "random",
-            "place_method": "jitter",
             "available_regions": {
                 "interior": {},
                 "surface": {}
@@ -84,7 +83,11 @@
                         "object": "red_sphere",
                         "count": 40
                     }
-                ]
+                ],
+                "surface": [{
+                    "object": "green_sphere",
+                    "count": 40
+                }]
             }
         },
         "inner_sphere": {

--- a/examples/recipes/v2/spheres_in_a_box.json
+++ b/examples/recipes/v2/spheres_in_a_box.json
@@ -1,0 +1,88 @@
+{
+    "version": "1.0.0",
+    "format_version": "2.0",
+    "name": "analysis_b",
+    "bounding_box": [
+        [
+            0,
+            0,
+            0
+        ],
+        [
+            1000,
+            1000,
+            1000
+        ]
+    ],
+    "objects": {
+        "base": {
+            "type": "single_sphere"
+
+        },
+        "sphere_100": {
+            "type": "single_sphere",
+            "inherit": "base",
+            "color": [
+                0.498,
+                0.498,
+                0.498
+            ],
+            "radius": 100
+        },
+        "sphere_200": {
+            "type": "single_sphere",
+            "inherit": "base",
+            "color": [
+                0.827,
+                0.82700002,
+                0.82700002
+            ],
+            "radius": 200
+        },
+        "sphere_50": {
+            "type": "single_sphere",
+            "inherit": "base",
+            "color": [
+                0.306,
+                0.45100001,
+                0.81599998
+            ],
+            "radius": 50
+        },
+        "sphere_25": {
+            "type": "single_sphere",
+            "inherit": "base",
+            "color": [
+                0.467,
+                0.23899999,
+                0.972
+            ],
+            "radius": 25
+        }
+    },
+    "composition": {
+        "space": {
+            "regions": {
+                "interior": [
+                    "A", "B", "C", "D"
+                ]
+            }
+        },
+        "A": {
+            "object": "sphere_100",
+            "count": 6
+        },
+        "B": {
+            "object": "sphere_200",
+            "count": 2
+        },
+        "C": {
+            "object": "sphere_50",
+            "count": 15
+        },
+        "D": {
+            "object": "sphere_25",
+            "count": 40
+        }
+    }
+}


### PR DESCRIPTION
Problem
=======
trimesh grid was not putting surface ingredients in the right spot with spheres as containers. 

Solution
========
raytrace worked and the only difference was "ex=True" so changed that. this should probably be dug into further in the future

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)
* Breaking change (fix or feature that would cause existing functionality to not work as expected)
* This change requires a documentation update
* This change requires updated or new tests

Change summary:
---------------
* Tidy, well formulated commit message
* Another great commit message
* Something else I/we did

Steps to Verify:
----------------
1. A setup step / beginning state
1. What to do next
1. Any other instructions
1. Expected behavior
1. Suggestions for testing

Screenshots (optional):
-----------------------
Show-n-tell images/animations here

Keyfiles (delete if not relevant):
-----------------------
1. main file/entry point
2. other important file

Thanks for contributing!
