### PR TITLE
fix: convert "type" Enums to strings in v1 recipe for firebase upload duplication check

### DIFF
--- a/cellpack/autopack/DBRecipeHandler.py
+++ b/cellpack/autopack/DBRecipeHandler.py
@@ -1,4 +1,5 @@
 import copy
+from enum import Enum
 
 from deepdiff import DeepDiff
 
@@ -404,6 +405,9 @@ class DBUploader(object):
                 modified_data[key] = unpacked_value
                 if isinstance(unpacked_value, dict):
                     modified_data[key] = DBUploader.prep_data_for_db(unpacked_value)
+            # If the value is an enum, convert it to a string. e.g. during a version migration process where "type" in a v1 recipe is an enum
+            elif isinstance(value, Enum):
+                modified_data[key] = value.name
             # If the value is a dictionary, recursively convert its nested lists to dictionaries
             elif isinstance(value, dict):
                 modified_data[key] = DBUploader.prep_data_for_db(value)


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
Found a bug: a v1 recipe could be uploaded to firebase more than once 

This issue arises because, during the version migration process, the "type" attribute of an object is converted into an Enum, whereas it is stored as a string in firebase database. So our duplication checking logic always find a difference in data types.

difference:
```
{
  "type_changes": {
    "root['type']": {
      "old_type": "<class 'str'>",
      "new_type": "<enum 'INGREDIENT_TYPE'>",
      "old_value": "single_sphere",
      "new_value": "<INGREDIENT_TYPE.SINGLE_SPHERE: 'single_sphere'>"
    }
  }
}

```

Solution
========
What I/we did to solve this problem
I added a value check for enum in the existing method `prep_data_for_db` within `DBRecipeHandler` 

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. in `DBRecipeHandler.py`, comment out the `return` in `DBUploader > upload_recipe()` to let deeper system checks into objects and compositions
2. run `upload -r examples/recipes/v1/one_sphere.json` to upload the recipe to your dev database
3. repeat the upload command to verify that the duplication check correctly identifies each object and composition, preventing duplicate uploads 

