### PR TITLE
set staging as the default database for S3 metadata storage

### DIFF
--- a/cellpack/autopack/FirebaseHandler.py
+++ b/cellpack/autopack/FirebaseHandler.py
@@ -16,10 +16,10 @@ class FirebaseHandler(object):
     _initialized = False
     _db = None
 
-    def __init__(self):
+    def __init__(self, default_db=None):
         # check if firebase is already initialized
         if not FirebaseHandler._initialized:
-            db_choice = FirebaseHandler.which_db()
+            db_choice = FirebaseHandler.which_db(default_db=default_db)
             if db_choice == "staging":
                 cred = FirebaseHandler.get_staging_creds()
             else:
@@ -34,14 +34,16 @@ class FirebaseHandler(object):
 
     # common utility methods
     @staticmethod
-    def which_db():
+    def which_db(default_db=None):
         options = {"1": "dev", "2": "staging"}
-        print("Choose database:")
+        if default_db in options.values():
+            print(f"Using {default_db} database -------------")
+            return default_db
         for key, value in options.items():
             print(f"[{key}] {value}")
         choice = input("Enter number: ").strip()
         print(f"Using {options.get(choice, 'dev')} database -------------")
-        return options.get(choice, "dev")  # default to dev db
+        return options.get(choice, "dev")  # default to dev db for recipe uploads
 
     @staticmethod
     def doc_to_dict(doc):

--- a/cellpack/autopack/FirebaseHandler.py
+++ b/cellpack/autopack/FirebaseHandler.py
@@ -103,12 +103,13 @@ class FirebaseHandler(object):
         # set override=True to refresh the .env file if softwares or tokens updated
         load_dotenv(dotenv_path="./.env", override=False)
         FIREBASE_TOKEN = os.getenv("FIREBASE_TOKEN")
+        firebase_key = FIREBASE_TOKEN.replace("\\n", "\n")
         FIREBASE_EMAIL = os.getenv("FIREBASE_EMAIL")
         return {
             "type": "service_account",
             "project_id": "cell-pack-database",
             "client_email": FIREBASE_EMAIL,
-            "private_key": FIREBASE_TOKEN,
+            "private_key": firebase_key,
             "token_uri": "https://oauth2.googleapis.com/token",
         }
 

--- a/cellpack/autopack/__init__.py
+++ b/cellpack/autopack/__init__.py
@@ -386,7 +386,8 @@ def load_file(filename, destination="", cache="geometries", force=None):
         # command example: `pack -r firebase:recipes/[FIREBASE-RECIPE-ID] -c [CONFIG-FILE-PATH]`
         if database_name == "firebase":
             db = DATABASE_IDS.handlers().get(database_name)
-            db_handler = DBRecipeLoader(db)
+            initialize_db = db()
+            db_handler = DBRecipeLoader(initialize_db)
             recipe_id = file_path.split("/")[-1]
             db_doc, _ = db_handler.collect_docs_by_id(
                 collection="recipes", id=recipe_id

--- a/cellpack/autopack/interface_objects/database_ids.py
+++ b/cellpack/autopack/interface_objects/database_ids.py
@@ -21,8 +21,11 @@ class DATABASE_IDS(MetaEnum):
                 region_name=region_name,
             )
 
+        def create_firebase_handler(default_db):
+            return FirebaseHandler(default_db=default_db)
+
         handlers_dict = {
-            cls.FIREBASE: FirebaseHandler(),
+            cls.FIREBASE: create_firebase_handler,
             cls.AWS: create_aws_handler,
         }
         return handlers_dict

--- a/cellpack/autopack/interface_objects/database_ids.py
+++ b/cellpack/autopack/interface_objects/database_ids.py
@@ -21,7 +21,7 @@ class DATABASE_IDS(MetaEnum):
                 region_name=region_name,
             )
 
-        def create_firebase_handler(default_db):
+        def create_firebase_handler(default_db=None):
             return FirebaseHandler(default_db=default_db)
 
         handlers_dict = {

--- a/cellpack/autopack/upy/simularium/simularium_helper.py
+++ b/cellpack/autopack/upy/simularium/simularium_helper.py
@@ -1423,8 +1423,12 @@ class simulariumHelper(hostHelper.Helper):
     @staticmethod
     def store_metadata(file_name, url, db=None):
         if db == "firebase":
-            db_handler = DBUploader(DATABASE_IDS.handlers().get(db))
-            db_handler.upload_result_metadata(file_name, url)
+            handler = DATABASE_IDS.handlers().get(db)
+            initialized_db = handler(
+                default_db="staging"
+            )  # default to staging for metadata uploads
+            db_uploader = DBUploader(initialized_db)
+            db_uploader.upload_result_metadata(file_name, url)
 
     @staticmethod
     def open_in_simularium(aws_url):


### PR DESCRIPTION
Problem
=======
Merge #230 before this PR

What is the problem this work solves, including
closes #233 #229 

Solution
========
What I/we did to solve this problem

- Added logic to initialize firebase handler with the `default_db` parameter if provided and applicable. 
- Set `default_db` to `staging` in `store_metadata()` within the simularium helper. 



## Type of change
Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)

Change summary:
---------------
* The system will now store S3 metadata in our staging firebase by default for each local packing 

Steps to Verify:
----------------
1. run any local recipe e.g `pack -r examples/recipes/v2/one_sphere.json -c examples/packing-configs/run.json`, it shouldn't prompt you to choose a database 
2. upload a local recipe and run the uploaded recipe to test if this change breaks anything

Screenshots (optional):
-----------------------
Show-n-tell images/animations here
<img width="1338" alt="Screenshot 2024-02-27 at 7 11 22 PM" src="https://github.com/mesoscope/cellpack/assets/91452427/39f1eed4-dbf6-4c45-be9e-6c067712fc8a">
