### PR TITLE
Skip staging db and aws on missing credentials 

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,12 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for information related to developing the
 
 ### Firebase Firestore
 1. Step-by-step Guide
-   * Create a Firebase project in test mode with your google account, select `firebase_admin` as the SDK. [Firebase Firestore tutorial](https://firebase.google.com/docs/firestore)
-   * Generate a new private key by navigating to "Project settings">"Service account" in the project's dashboard.
+   * For dev database:
+     * Create a Firebase project in test mode with your google account, select `firebase_admin` as the SDK. [Firebase Firestore tutorial](https://firebase.google.com/docs/firestore)
+     * Generate a new private key by navigating to "Project settings">"Service account" in the project's dashboard.
+   * For staging database:
+       * Reach out to the code owner for the necessary credentials.
+       * Set up an `.env` file as instructed.
 
 **MIT license**
 

--- a/cellpack/autopack/AWSHandler.py
+++ b/cellpack/autopack/AWSHandler.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from urllib.parse import parse_qs, urlparse, urlunparse
 
 import boto3
-from botocore.exceptions import ClientError
+from botocore.exceptions import ClientError, NoCredentialsError
 
 
 class AWSHandler(object):
@@ -115,8 +115,26 @@ class AWSHandler(object):
         """
         Uploads a file to S3 and returns the base url
         """
-        file_name = self.upload_file(file_path)
-        base_url = self.create_presigned_url(file_name)
-        if file_name and base_url:
-            if self.is_url_valid(base_url):
-                return file_name, base_url
+        try:
+            file_name = self.upload_file(file_path)
+            base_url = self.create_presigned_url(file_name)
+            if file_name and base_url:
+                if self.is_url_valid(base_url):
+                    return file_name, base_url
+        except NoCredentialsError as e:
+            print(self.skip_aws_credentials(e))
+            return None, None
+        return None, None
+
+    @staticmethod
+    def skip_aws_credentials(e):
+        """
+        Handles the case when AWS credentials are not configured.
+        Provides a detailed error message and instruction.
+        """
+        aws_readme_url = (
+                "https://github.com/mesoscope/cellpack/blob/main/README.md#aws-s3"
+            )
+        return (
+            f"AWS credentials are not configured, details:{e}. If needed, find instructions here: {aws_readme_url}. \nSkipping AWS. Manual result viewing required  -------------"
+        )

--- a/cellpack/autopack/AWSHandler.py
+++ b/cellpack/autopack/AWSHandler.py
@@ -122,17 +122,6 @@ class AWSHandler(object):
                 if self.is_url_valid(base_url):
                     return file_name, base_url
         except NoCredentialsError as e:
-            print(self.skip_aws_credentials(e))
+            print(f"AWS credentials are not configured, details:{e}")
             return None, None
         return None, None
-
-    @staticmethod
-    def skip_aws_credentials(e):
-        """
-        Handles the case when AWS credentials are not configured.
-        Provides a detailed error message and instruction.
-        """
-        aws_readme_url = (
-            "https://github.com/mesoscope/cellpack/blob/main/README.md#aws-s3"
-        )
-        return f"AWS credentials are not configured, details:{e}. If needed, refer to the instructions at {aws_readme_url}. \nSkipping the opening of new browser tabs  -------------"

--- a/cellpack/autopack/AWSHandler.py
+++ b/cellpack/autopack/AWSHandler.py
@@ -133,8 +133,6 @@ class AWSHandler(object):
         Provides a detailed error message and instruction.
         """
         aws_readme_url = (
-                "https://github.com/mesoscope/cellpack/blob/main/README.md#aws-s3"
-            )
-        return (
-            f"AWS credentials are not configured, details:{e}. If needed, find instructions here: {aws_readme_url}. \nSkipping AWS. Manual result viewing required  -------------"
+            "https://github.com/mesoscope/cellpack/blob/main/README.md#aws-s3"
         )
+        return f"AWS credentials are not configured, details:{e}. If needed, refer to the instructions at {aws_readme_url}. \nSkipping the opening of new browser tabs  -------------"

--- a/cellpack/autopack/DBRecipeHandler.py
+++ b/cellpack/autopack/DBRecipeHandler.py
@@ -771,3 +771,9 @@ class DBMaintenance(object):
         Check if the results in the database are expired and delete them if the linked object expired.
         """
         self.result_doc.handle_expired_results()
+
+    def readme_url(self):
+        """
+        Return the URL to the README file for the database setup section.
+        """
+        return "https://github.com/mesoscope/cellpack?tab=readme-ov-file#introduction-to-remote-databases"

--- a/cellpack/autopack/FirebaseHandler.py
+++ b/cellpack/autopack/FirebaseHandler.py
@@ -120,12 +120,12 @@ class FirebaseHandler(object):
     def get_staging_creds():
         # set override=True to refresh the .env file if softwares or tokens updated
         load_dotenv(dotenv_path="./.env", override=False)
-        # FIREBASE_TOKEN = os.getenv("FIREBASE_TOKEN")
-        # FIREBASE_EMAIL = os.getenv("FIREBASE_EMAIL")
-        FIREBASE_TOKEN = None
-        FIREBASE_EMAIL = None
+        FIREBASE_TOKEN = os.getenv("FIREBASE_TOKEN")
+        FIREBASE_EMAIL = os.getenv("FIREBASE_EMAIL")
         if not FIREBASE_TOKEN or not FIREBASE_EMAIL:
-            print("Firebase credentials are not found. If needed, please contact the code owner for assistance. \nSkipping firebase staging database -------------")
+            print(
+                "Firebase credentials are not found. If needed, please contact the code owner for assistance. \nSkipping firebase staging database -------------"
+            )
             return
         firebase_key = FIREBASE_TOKEN.replace("\\n", "\n")
         return {

--- a/cellpack/autopack/FirebaseHandler.py
+++ b/cellpack/autopack/FirebaseHandler.py
@@ -123,9 +123,6 @@ class FirebaseHandler(object):
         FIREBASE_TOKEN = os.getenv("FIREBASE_TOKEN")
         FIREBASE_EMAIL = os.getenv("FIREBASE_EMAIL")
         if not FIREBASE_TOKEN or not FIREBASE_EMAIL:
-            print(
-                "Firebase credentials are not found. If needed, please contact the code owner for assistance. \nSkipping firebase staging database -------------"
-            )
             return
         firebase_key = FIREBASE_TOKEN.replace("\\n", "\n")
         return {

--- a/cellpack/autopack/__init__.py
+++ b/cellpack/autopack/__init__.py
@@ -388,8 +388,9 @@ def load_file(filename, destination="", cache="geometries", force=None):
             db = DATABASE_IDS.handlers().get(database_name)
             initialize_db = db()
             if not initialize_db._initialized:
+                readme_url = "https://github.com/mesoscope/cellpack?tab=readme-ov-file#introduction-to-remote-databases"
                 sys.exit(
-                    "The selected database is not initialized. Please set up Firebase credentials to pack remote recipes."
+                    f"The selected database is not initialized. Please set up Firebase credentials to pack remote recipes. Refer to the instructions at {readme_url}"
                 )
             db_handler = DBRecipeLoader(initialize_db)
             recipe_id = file_path.split("/")[-1]

--- a/cellpack/autopack/__init__.py
+++ b/cellpack/autopack/__init__.py
@@ -388,7 +388,9 @@ def load_file(filename, destination="", cache="geometries", force=None):
             db = DATABASE_IDS.handlers().get(database_name)
             initialize_db = db()
             if not initialize_db._initialized:
-                sys.exit("The selected database is not initialized. Please set up Firebase credentials to pack remote recipes.")
+                sys.exit(
+                    "The selected database is not initialized. Please set up Firebase credentials to pack remote recipes."
+                )
             db_handler = DBRecipeLoader(initialize_db)
             recipe_id = file_path.split("/")[-1]
             db_doc, _ = db_handler.collect_docs_by_id(

--- a/cellpack/autopack/__init__.py
+++ b/cellpack/autopack/__init__.py
@@ -387,6 +387,8 @@ def load_file(filename, destination="", cache="geometries", force=None):
         if database_name == "firebase":
             db = DATABASE_IDS.handlers().get(database_name)
             initialize_db = db()
+            if not initialize_db._initialized:
+                sys.exit("The selected database is not initialized. Please set up Firebase credentials to pack remote recipes.")
             db_handler = DBRecipeLoader(initialize_db)
             recipe_id = file_path.split("/")[-1]
             db_doc, _ = db_handler.collect_docs_by_id(

--- a/cellpack/autopack/upy/simularium/simularium_helper.py
+++ b/cellpack/autopack/upy/simularium/simularium_helper.py
@@ -1390,22 +1390,11 @@ class simulariumHelper(hostHelper.Helper):
     def post_and_open_file(self, file_name, open_results_in_browser=True):
         simularium_file = Path(f"{file_name}.simularium")
         url = None
-        try:
-            _, url = simulariumHelper.store_result_file(simularium_file, storage="aws")
-        except Exception as e:
-            aws_readme_url = (
-                "https://github.com/mesoscope/cellpack/blob/main/README.md#aws-s3"
-            )
-            if isinstance(e, NoCredentialsError):
-                print(
-                    f"need to configure your aws account, find instructions here: {aws_readme_url}"
-                )
-            else:
-                print(
-                    f"An error occurred while storing the file {simularium_file} to S3: {e}"
-                )
-        if url is not None and open_results_in_browser:
-            simulariumHelper.open_in_simularium(url)
+        file_name, url = simulariumHelper.store_result_file(simularium_file, storage="aws")
+        if file_name and url:
+            simulariumHelper.store_metadata(file_name, url, db="firebase")
+            if open_results_in_browser:
+                simulariumHelper.open_in_simularium(url)
 
     @staticmethod
     def store_result_file(file_path, storage=None):
@@ -1416,8 +1405,7 @@ class simulariumHelper(hostHelper.Helper):
                 sub_folder_name="simularium",
                 region_name="us-west-2",
             )
-        file_name, url = initialized_handler.save_file_and_get_url(file_path)
-        simulariumHelper.store_metadata(file_name, url, db="firebase")
+            file_name, url = initialized_handler.save_file_and_get_url(file_path)
         return file_name, url
 
     @staticmethod
@@ -1427,8 +1415,10 @@ class simulariumHelper(hostHelper.Helper):
             initialized_db = handler(
                 default_db="staging"
             )  # default to staging for metadata uploads
-            db_uploader = DBUploader(initialized_db)
-            db_uploader.upload_result_metadata(file_name, url)
+            if initialized_db._initialized:
+                db_uploader = DBUploader(initialized_db)
+                db_uploader.upload_result_metadata(file_name, url)
+        return 
 
     @staticmethod
     def open_in_simularium(aws_url):

--- a/cellpack/autopack/upy/simularium/simularium_helper.py
+++ b/cellpack/autopack/upy/simularium/simularium_helper.py
@@ -7,7 +7,6 @@ from pathlib import Path
 import matplotlib
 import numpy as np
 import trimesh
-from botocore.exceptions import NoCredentialsError
 
 from simulariumio import (
     TrajectoryConverter,

--- a/cellpack/autopack/upy/simularium/simularium_helper.py
+++ b/cellpack/autopack/upy/simularium/simularium_helper.py
@@ -1390,7 +1390,9 @@ class simulariumHelper(hostHelper.Helper):
     def post_and_open_file(self, file_name, open_results_in_browser=True):
         simularium_file = Path(f"{file_name}.simularium")
         url = None
-        file_name, url = simulariumHelper.store_result_file(simularium_file, storage="aws")
+        file_name, url = simulariumHelper.store_result_file(
+            simularium_file, storage="aws"
+        )
         if file_name and url:
             simulariumHelper.store_metadata(file_name, url, db="firebase")
             if open_results_in_browser:
@@ -1418,7 +1420,7 @@ class simulariumHelper(hostHelper.Helper):
             if initialized_db._initialized:
                 db_uploader = DBUploader(initialized_db)
                 db_uploader.upload_result_metadata(file_name, url)
-        return 
+        return
 
     @staticmethod
     def open_in_simularium(aws_url):

--- a/cellpack/autopack/upy/simularium/simularium_helper.py
+++ b/cellpack/autopack/upy/simularium/simularium_helper.py
@@ -22,7 +22,7 @@ from simulariumio.cellpack import CellpackConverter, HAND_TYPE
 from simulariumio.constants import DISPLAY_TYPE, VIZ_TYPE
 
 from cellpack.autopack.upy import hostHelper
-from cellpack.autopack.DBRecipeHandler import DBUploader
+from cellpack.autopack.DBRecipeHandler import DBUploader, DBMaintenance
 from cellpack.autopack.interface_objects.database_ids import DATABASE_IDS
 import collada
 
@@ -1407,6 +1407,11 @@ class simulariumHelper(hostHelper.Helper):
                 region_name="us-west-2",
             )
             file_name, url = initialized_handler.save_file_and_get_url(file_path)
+            if not file_name or not url:
+                db_maintainer = DBMaintenance(initialized_handler)
+                print(
+                    f"If AWS access needed, please refer to the instructions at {db_maintainer.readme_url()}. \nSkipping the opening of new browser tabs  -------------"
+                )
         return file_name, url
 
     @staticmethod
@@ -1419,6 +1424,11 @@ class simulariumHelper(hostHelper.Helper):
             if initialized_db._initialized:
                 db_uploader = DBUploader(initialized_db)
                 db_uploader.upload_result_metadata(file_name, url)
+            else:
+                db_maintainer = DBMaintenance(initialized_db)
+                print(
+                    f"Firebase credentials are not found. If needed, please refer to the instructions at {db_maintainer.readme_url()}. \nSkipping firebase staging database -------------"
+                )
         return
 
     @staticmethod

--- a/cellpack/bin/upload.py
+++ b/cellpack/bin/upload.py
@@ -2,7 +2,7 @@ import sys
 import fire
 
 from cellpack.autopack.FirebaseHandler import FirebaseHandler
-from cellpack.autopack.DBRecipeHandler import DBUploader
+from cellpack.autopack.DBRecipeHandler import DBUploader, DBMaintenance
 
 from cellpack.autopack.interface_objects.database_ids import DATABASE_IDS
 from cellpack.autopack.loaders.recipe_loader import RecipeLoader
@@ -27,8 +27,9 @@ def upload(
             recipe_db_handler = DBUploader(db_handler)
             recipe_db_handler.upload_recipe(recipe_meta_data, recipe_full_data)
         else:
+            db_maintainer = DBMaintenance(db_handler)
             sys.exit(
-                "The selected database is not initialized. Please set up Firebase credentials to upload recipes."
+                f"The selected database is not initialized. Please set up Firebase credentials to upload recipes. Refer to the instructions at {db_maintainer.readme_url()} "
             )
 
 

--- a/cellpack/bin/upload.py
+++ b/cellpack/bin/upload.py
@@ -36,8 +36,9 @@ def upload(
             recipe_db_handler = DBUploader(db_handler)
             recipe_db_handler.upload_recipe(recipe_meta_data, recipe_full_data)
         else:
-            sys.exit("The selected database is not initialized. Please set up Firebase credentials to upload recipes.")
-            
+            sys.exit(
+                "The selected database is not initialized. Please set up Firebase credentials to upload recipes."
+            )
 
 
 def main():

--- a/cellpack/bin/upload.py
+++ b/cellpack/bin/upload.py
@@ -1,20 +1,11 @@
 import sys
 import fire
-from pathlib import Path
-import logging
-import logging.config
 
 from cellpack.autopack.FirebaseHandler import FirebaseHandler
 from cellpack.autopack.DBRecipeHandler import DBUploader
 
 from cellpack.autopack.interface_objects.database_ids import DATABASE_IDS
 from cellpack.autopack.loaders.recipe_loader import RecipeLoader
-
-###############################################################################
-log_file_path = Path(__file__).parent.parent / "logging.conf"
-logging.config.fileConfig(log_file_path, disable_existing_loggers=False)
-log = logging.getLogger()
-###############################################################################
 
 
 def upload(

--- a/cellpack/bin/upload.py
+++ b/cellpack/bin/upload.py
@@ -1,9 +1,20 @@
+import sys
 import fire
+from pathlib import Path
+import logging
+import logging.config
+
 from cellpack.autopack.FirebaseHandler import FirebaseHandler
 from cellpack.autopack.DBRecipeHandler import DBUploader
 
 from cellpack.autopack.interface_objects.database_ids import DATABASE_IDS
 from cellpack.autopack.loaders.recipe_loader import RecipeLoader
+
+###############################################################################
+log_file_path = Path(__file__).parent.parent / "logging.conf"
+logging.config.fileConfig(log_file_path, disable_existing_loggers=False)
+log = logging.getLogger()
+###############################################################################
 
 
 def upload(
@@ -18,11 +29,15 @@ def upload(
     if db_id == DATABASE_IDS.FIREBASE:
         # fetch the service key json file
         db_handler = FirebaseHandler()
-        recipe_loader = RecipeLoader(recipe_path)
-        recipe_full_data = recipe_loader._read(resolve_inheritance=False)
-        recipe_meta_data = recipe_loader.get_only_recipe_metadata()
-        recipe_db_handler = DBUploader(db_handler)
-        recipe_db_handler.upload_recipe(recipe_meta_data, recipe_full_data)
+        if FirebaseHandler._initialized:
+            recipe_loader = RecipeLoader(recipe_path)
+            recipe_full_data = recipe_loader._read(resolve_inheritance=False)
+            recipe_meta_data = recipe_loader.get_only_recipe_metadata()
+            recipe_db_handler = DBUploader(db_handler)
+            recipe_db_handler.upload_recipe(recipe_meta_data, recipe_full_data)
+        else:
+            sys.exit("The selected database is not initialized. Please set up Firebase credentials to upload recipes.")
+            
 
 
 def main():


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
closes #238  

Solution
========
To address the issue of missing aws or firebase credentials when running local packings, the following changes were made:
    - skipped the saving process for staging database and aws s3 bucket 
    - disabled the automatic opening of new browser tabs related to aws urls 
    - updated documentation 
 
## Type of change
Please delete options that are not relevant.
* New feature (non-breaking change which adds functionality)
* documentation update

Steps to Verify:
----------------
1. Temporarily remove your credentials 
2. Pack a local recipe to ensure the system behaves as expected without credentials. 
3. Optionally, upload or pack a remote recipe to verify that the process functions as intended with/without credentials in place 


