### PR TITLE
Fix github action job: Version 3.9 with arch x64 not found

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.10]
+        python-version: ["3.10"]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
@@ -53,7 +53,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.10
+        python-version: "3.10"
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip
@@ -80,7 +80,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.10
+        python-version: "3.10"
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip
@@ -89,5 +89,5 @@ jobs:
       run: |
         python setup.py sdist bdist_wheel
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1 
+      uses: pypa/gh-action-pypi-publish@release/v1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,13 +26,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Dependencies
@@ -80,7 +80,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.9
+        python-version: "3.x"
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Continuous Integration
 on:
   push:
     branches:
-      - main
+      - update/python_version
     tags:
       - "v*"
   pull_request:
@@ -26,7 +26,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.x"]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: 3.11
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,5 +89,5 @@ jobs:
       run: |
         python setup.py sdist bdist_wheel
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@release/v1 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.11]
+        python-version: [3.10]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
@@ -53,7 +53,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.11
+        python-version: 3.10
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip
@@ -80,7 +80,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.11
+        python-version: 3.10
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.x"]
+        python-version: [3.11]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
@@ -80,7 +80,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: "3.x"
+        python-version: 3.11
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: [3.9]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
@@ -53,7 +53,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: 3.9
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip
@@ -76,11 +76,11 @@ jobs:
       id-token: write
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: 3.9
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Continuous Integration
 on:
   push:
     branches:
-      - update/python_version
+      - main
     tags:
       - "v*"
   pull_request:

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ requirements = [
     "fire>=0.4.0",
     "firebase_admin>=6.0.1",
     "matplotlib>=3.3.4",
-    "numpy>=1.19.2",
+    "numpy>=1.26.4",
     "pmw==2.0.1",
     "scipy>=1.6.2",
     "simulariumio>=1.6.3",

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ requirements = [
     "fire>=0.4.0",
     "firebase_admin>=6.0.1",
     "matplotlib>=3.3.4",
-    "numpy>=1.26.4",
+    "numpy>=1.19.2",
     "pmw==2.0.1",
     "scipy>=1.6.2",
     "simulariumio>=1.6.3",


### PR DESCRIPTION
Merge this pr first

Problem
=======
What is the problem this work solves, including
CI/CD issue: `Error: Version 3.9 with arch x64 not found`

Solution
========
What I/we did to solve this problem
~~Made a few adjustments, and turns out using python 3.10 - currently the most stable version for cellPACK.~~
updated `checkout` and `setup-python`

## Type of change
Please delete options that are not relevant.

* Bug fix and version update (non-breaking change which fixes an issue)
