### PR TITLE
Feature/add plots to result

### DIFF
--- a/cellpack/autopack/Analysis.py
+++ b/cellpack/autopack/Analysis.py
@@ -57,7 +57,6 @@ class Analysis:
             self.smallest = env.smallestProteinSize
             self.largest = env.largestProteinSize
         self.afviewer = viewer
-        self.helper = None
         if viewer:
             self.helper = self.afviewer.vi
         self.result_file = result_file
@@ -86,6 +85,7 @@ class Analysis:
         self.figures_path = self.output_path / "figures"
         self.figures_path.mkdir(parents=True, exist_ok=True)
         self.seed_to_results = {}
+        self.helper = autopack.helper
         autopack._colors = None
 
     @staticmethod
@@ -643,6 +643,11 @@ class Analysis:
                 x_label=dim,
                 y_label="count",
             )
+            self.helper.plot_data.add_histogram(
+                title="all_ingredients",
+                xaxis_title=dim,
+                traces={"count": all_pos[:, ind]},
+            )
 
     def plot_position_distribution(self, ingr):
         pos_xyz = numpy.array(self.env.ingredient_positions[ingr.name])
@@ -657,6 +662,9 @@ class Analysis:
                 title_str=ingr.name,
                 x_label=dim,
                 y_label="count",
+            )
+            self.helper.plot_data.add_histogram(
+                title=ingr.name, xaxis_title=dim, traces={"count": all_pos[:, ind]}
             )
 
     def plot_occurence_distribution(self, ingr):
@@ -680,6 +688,11 @@ class Analysis:
             x_label="occurrences",
             y_label="count",
         )
+        self.helper.plot_data.add_histogram(
+            title=ingr.name,
+            xaxis_title="occurrences",
+            traces={"count": numpy.array(occ)},
+        )
 
     def plot_distance_distribution(self, all_ingredient_distances):
         """
@@ -695,6 +708,11 @@ class Analysis:
                 title_str=ingr_key,
                 x_label="pairwise distance",
                 y_label="count",
+            )
+            self.helper.plot_data.add_histogram(
+                title=ingr_key,
+                xaxis_title="pairwise distance",
+                traces={"count": numpy.array(distances)},
             )
 
     def correlation(self, ingr):
@@ -2181,7 +2199,6 @@ class Analysis:
             self.afviewer.clearFill("Test_Spheres2D")
         else:
             self.env.reset()
-        self.env.saveResult = True
         numpy.random.seed(seed)
         self.build_grid()
         two_d = self.env.is_two_d()
@@ -2331,6 +2348,7 @@ class Analysis:
                 grid_image_writer = gradient.create_voxelization(grid_image_writer)
                 grid_image_writer.export_image()
 
+        Writer().save_as_simularium(self.env, self.seed_to_results)
         return (
             center_distance_dict,
             pairwise_distance_dict,
@@ -2498,9 +2516,6 @@ class Analysis:
         self.writeJSON(ingredient_occurences_file, ingredient_occurence_dict)
         self.writeJSON(ingredient_key_file, ingredient_key_dict)
 
-        if number_of_packings > 1:
-            Writer().save_as_simularium(self.env, self.seed_to_results)
-
         all_ingredient_positions = self.combine_results_from_seeds(
             ingredient_position_dict
         )
@@ -2559,6 +2574,11 @@ class Analysis:
                     x_label="center distance",
                     y_label="count",
                 )
+                self.helper.plot_data.add_histogram(
+                    title="all_ingredients",
+                    xaxis_title="center distance",
+                    traces={"count": numpy.array(all_center_distance_array)},
+                )
 
             if len(all_center_distance_array) > 1:
                 self.histogram(
@@ -2568,6 +2588,11 @@ class Analysis:
                     title_str="all_ingredients",
                     x_label="pairwise distances",
                     y_label="count",
+                )
+                self.helper.plot_data.add_histogram(
+                    title="all_ingredients",
+                    xaxis_title="pairwise distances",
+                    traces={"count": numpy.array(all_pairwise_distance_array)},
                 )
 
             # plot the angle
@@ -2579,12 +2604,22 @@ class Analysis:
                     x_label="angles X",
                     y_label="count",
                 )
+                self.helper.plot_data.add_histogram(
+                    title="all_ingredients",
+                    xaxis_title="angles X",
+                    traces={"count": numpy.array(all_ingredient_angle_array[0])},
+                )
                 self.histogram(
                     all_ingredient_angle_array[1],
                     self.figures_path / f"all_angles_Y_{self.env.basename}.png",
                     title_str="all_ingredients",
                     x_label="angles Y",
                     y_label="count",
+                )
+                self.helper.plot_data.add_histogram(
+                    title="all_ingredients",
+                    xaxis_title="angles Y",
+                    traces={"count": numpy.array(all_ingredient_angle_array[1])},
                 )
                 self.histogram(
                     all_ingredient_angle_array[2],
@@ -2593,3 +2628,9 @@ class Analysis:
                     x_label="angles Z",
                     y_label="count",
                 )
+                self.helper.plot_data.add_histogram(
+                    title="all_ingredients",
+                    xaxis_title="angles Z",
+                    traces={"count": numpy.array(all_ingredient_angle_array[2])},
+                )
+        Writer().save_as_simularium(self.env, self.seed_to_results)

--- a/cellpack/autopack/Analysis.py
+++ b/cellpack/autopack/Analysis.py
@@ -695,6 +695,7 @@ class Analysis:
                 title_str=ingr_key,
                 x_label="pairwise distance",
                 y_label="count",
+                save_png=True,
             )
 
     def correlation(self, ingr):
@@ -1727,6 +1728,7 @@ class Analysis:
             plt.ylabel(y_label)
             plt.savefig(filename)
             plt.close()
+            print("saved", filename)
 
         if add_to_result:
             # add histogrm to result file and display on the web page

--- a/cellpack/autopack/Analysis.py
+++ b/cellpack/autopack/Analysis.py
@@ -2202,8 +2202,6 @@ class Analysis:
             self.afviewer.clearFill("Test_Spheres2D")
         else:
             self.env.reset()
-        # TODO: why we set saveResult to True here? can we add a condition?
-        # self.env.saveResult = True
         numpy.random.seed(seed)
         self.build_grid()
         two_d = self.env.is_two_d()

--- a/cellpack/autopack/Analysis.py
+++ b/cellpack/autopack/Analysis.py
@@ -2347,8 +2347,6 @@ class Analysis:
                 )
                 grid_image_writer = gradient.create_voxelization(grid_image_writer)
                 grid_image_writer.export_image()
-
-        Writer().save_as_simularium(self.env, self.seed_to_results)
         return (
             center_distance_dict,
             pairwise_distance_dict,

--- a/cellpack/autopack/Analysis.py
+++ b/cellpack/autopack/Analysis.py
@@ -588,7 +588,23 @@ class Analysis:
                 **analysis_config["create_report"],
             )
 
-    def histogram(self, distances, filename, title_str="", x_label="", y_label="", save_png=True, add_to_result=True):
+    def histogram(
+        self,
+        distances,
+        filename,
+        title_str="",
+        x_label="",
+        y_label="",
+        add_to_result=True,
+        save_png=False,
+    ):
+        if add_to_result:
+            # add histogrm to result file and display on the web page
+            self.helper.plot_data.add_histogram(
+                title=f"{title_str}: {x_label}",
+                xaxis_title=x_label,
+                traces={y_label: numpy.array(distances)},
+            )
         if save_png:
             # use matplotlib to create histogram and save as png
             plt.clf()
@@ -619,14 +635,6 @@ class Analysis:
             plt.ylabel(y_label)
             plt.savefig(filename)
             plt.close()
-
-        if add_to_result:
-            # add histogrm to result file and display on the web page
-            self.helper.plot_data.add_histogram(
-                title=f"{title_str}: {x_label}",
-                xaxis_title=x_label,
-                traces={y_label: numpy.array(distances)},
-            )
 
     def plot(self, rdf, radii, file_name):
         plt.clf()

--- a/cellpack/autopack/Analysis.py
+++ b/cellpack/autopack/Analysis.py
@@ -2199,6 +2199,8 @@ class Analysis:
             self.afviewer.clearFill("Test_Spheres2D")
         else:
             self.env.reset()
+        # TODO: why we set saveResult to True here? can we add a condition?
+        # self.env.saveResult = True
         numpy.random.seed(seed)
         self.build_grid()
         two_d = self.env.is_two_d()

--- a/cellpack/autopack/Environment.py
+++ b/cellpack/autopack/Environment.py
@@ -2178,9 +2178,7 @@ class Environment(CompartmentList):
             pbar.close()
         self.log.info("time to fill %d", t2 - t1)
         all_objects = self.prep_molecules_for_save(distances, free_points, nbFreePoints)
-        print("SELF.result", self.saveResult)
         if self.saveResult:
-            print("SAVING FROM ENV")
             self.save_result(
                 free_points,
                 distances=distances,

--- a/cellpack/autopack/Environment.py
+++ b/cellpack/autopack/Environment.py
@@ -143,7 +143,11 @@ class Environment(CompartmentList):
         self.name = name
         self.version = recipe.get("version", "default")
         # saving/pickle option
-        self.saveResult = "out" in config
+        self.saveResult = (
+            "out" in config
+            and not config["save_analyze_result"]
+            and not config["number_of_packings"] > 1
+        )
         self.out_folder = create_output_dir(config["out"], name, config["place_method"])
         self.base_name = f"{self.name}_{config['name']}_{self.version}"
         self.grid_file_out = (
@@ -2174,8 +2178,9 @@ class Environment(CompartmentList):
             pbar.close()
         self.log.info("time to fill %d", t2 - t1)
         all_objects = self.prep_molecules_for_save(distances, free_points, nbFreePoints)
-
+        print("SELF.result", self.saveResult)
         if self.saveResult:
+            print("SAVING FROM ENV")
             self.save_result(
                 free_points,
                 distances=distances,

--- a/cellpack/autopack/upy/simularium/plots.py
+++ b/cellpack/autopack/upy/simularium/plots.py
@@ -1,0 +1,36 @@
+import numpy as np
+from simulariumio import ScatterPlotData, HistogramPlotData
+
+
+class PlotData:
+    def __init__(self):
+        self.plot_list = []  # list of tuples
+
+    def _add_plot(self, plot):
+        self.plot_list.append(plot)
+
+    def add_scatter(self, title, xaxis_title, yaxis_title, xtrace, ytraces):
+        self._add_plot(
+            (
+                "scatter",
+                ScatterPlotData(
+                    title=title,
+                    xaxis_title=xaxis_title,
+                    yaxis_title=yaxis_title,
+                    xtrace=np.array(xtrace),
+                    ytraces={key: np.array(value) for key, value in ytraces.items()},
+                ),
+            )
+        )
+
+    def add_histogram(self, title, xaxis_title, traces):
+        self._add_plot(
+            (
+                "histogram",
+                HistogramPlotData(
+                    title=title,
+                    xaxis_title=xaxis_title,
+                    traces={key: np.array(value) for key, value in traces.items()},
+                ),
+            )
+        )

--- a/cellpack/autopack/upy/simularium/simularium_helper.py
+++ b/cellpack/autopack/upy/simularium/simularium_helper.py
@@ -18,6 +18,7 @@ from simulariumio import (
     ModelMetaData,
     CameraData,
     DisplayData,
+    ScatterPlotData,
 )
 from simulariumio.cellpack import CellpackConverter, HAND_TYPE
 from simulariumio.constants import DISPLAY_TYPE, VIZ_TYPE
@@ -1371,7 +1372,64 @@ class simulariumHelper(hostHelper.Helper):
             time_units=UnitData("ns"),  # nanoseconds
             spatial_units=UnitData("nm"),  # nanometers
         )
-        TrajectoryConverter(converted_data).save(file_name, False)
+        plot_data = ScatterPlotData(
+            title="test_plot",
+            xaxis_title="concentrations (uM)",
+            yaxis_title="time (s)",
+            xtrace=np.array(
+                [
+                    0.0,
+                    1.0,
+                    2.0,
+                    3.0,
+                    4.0,
+                    5.0,
+                    6.0,
+                    7.0,
+                    8.0,
+                    9.0,
+                    3.0,
+                    4.0,
+                    3.0,
+                    7.0,
+                    5.0,
+                    3.0,
+                    6.0,
+                    5.0,
+                    2.0,
+                    4.0,
+                ]
+            ),
+            ytraces={
+                "agent1": np.array(
+                    [
+                        0.0,
+                        1.0,
+                        2.0,
+                        3.0,
+                        4.0,
+                        5.0,
+                        6.0,
+                        7.0,
+                        8.0,
+                        9.0,
+                        3.0,
+                        4.0,
+                        3.0,
+                        7.0,
+                        5.0,
+                        3.0,
+                        6.0,
+                        5.0,
+                        2.0,
+                        4.0,
+                    ]
+                ),
+            },
+        )
+        trajectory_converter = TrajectoryConverter(converted_data)
+        trajectory_converter.add_plot(plot_data, "scatter")
+        trajectory_converter.save(file_name, False)
         return file_name
 
     def raycast(self, **kw):

--- a/cellpack/autopack/upy/simularium/simularium_helper.py
+++ b/cellpack/autopack/upy/simularium/simularium_helper.py
@@ -19,6 +19,7 @@ from simulariumio import (
     CameraData,
     DisplayData,
     ScatterPlotData,
+    HistogramPlotData,
 )
 from simulariumio.cellpack import CellpackConverter, HAND_TYPE
 from simulariumio.constants import DISPLAY_TYPE, VIZ_TYPE
@@ -1373,35 +1374,65 @@ class simulariumHelper(hostHelper.Helper):
             spatial_units=UnitData("nm"),  # nanometers
         )
         converter = TrajectoryConverter(converted_data)
-        plot_data = ScatterPlotData(
-            title="test_plot",
+        # plot_data = ScatterPlotData(
+        #     title="test_plot",
+        #     xaxis_title="concentrations (uM)",
+        #     yaxis_title="time (s)",
+        #     xtrace=np.array(
+        #         [
+        #             0.0,
+        #             1.0,
+        #             2.0,
+        #             3.0,
+        #             4.0,
+        #             5.0,
+        #             6.0,
+        #             7.0,
+        #             8.0,
+        #             9.0,
+        #             3.0,
+        #             4.0,
+        #             3.0,
+        #             7.0,
+        #             5.0,
+        #             3.0,
+        #             6.0,
+        #             5.0,
+        #             2.0,
+        #             4.0,
+        #         ]
+        #     ),
+        #     ytraces={
+        #         "agent1": np.array(
+        #             [
+        #                 0.0,
+        #                 1.0,
+        #                 2.0,
+        #                 3.0,
+        #                 4.0,
+        #                 5.0,
+        #                 6.0,
+        #                 7.0,
+        #                 8.0,
+        #                 9.0,
+        #                 3.0,
+        #                 4.0,
+        #                 3.0,
+        #                 7.0,
+        #                 5.0,
+        #                 3.0,
+        #                 6.0,
+        #                 5.0,
+        #                 2.0,
+        #                 4.0,
+        #             ]
+        #         ),
+        #     },
+        # )
+        plot_data = HistogramPlotData(
+            title="Test Histogram 2",
             xaxis_title="concentrations (uM)",
-            yaxis_title="time (s)",
-            xtrace=np.array(
-                [
-                    0.0,
-                    1.0,
-                    2.0,
-                    3.0,
-                    4.0,
-                    5.0,
-                    6.0,
-                    7.0,
-                    8.0,
-                    9.0,
-                    3.0,
-                    4.0,
-                    3.0,
-                    7.0,
-                    5.0,
-                    3.0,
-                    6.0,
-                    5.0,
-                    2.0,
-                    4.0,
-                ]
-            ),
-            ytraces={
+            traces={
                 "agent1": np.array(
                     [
                         0.0,
@@ -1428,8 +1459,8 @@ class simulariumHelper(hostHelper.Helper):
                 ),
             },
         )
-        converter.add_plot(plot_data, "scatter")
-        converter.save(file_name)
+        converter.add_plot(plot_data, "histogram")
+        converter.save(file_name, False)
         return file_name
 
     def raycast(self, **kw):

--- a/cellpack/autopack/upy/simularium/simularium_helper.py
+++ b/cellpack/autopack/upy/simularium/simularium_helper.py
@@ -17,13 +17,12 @@ from simulariumio import (
     ModelMetaData,
     CameraData,
     DisplayData,
-    ScatterPlotData,
-    HistogramPlotData,
 )
 from simulariumio.cellpack import CellpackConverter, HAND_TYPE
 from simulariumio.constants import DISPLAY_TYPE, VIZ_TYPE
 
 from cellpack.autopack.upy import hostHelper
+from cellpack.autopack.upy.simularium.plots import PlotData
 from cellpack.autopack.DBRecipeHandler import DBUploader, DBMaintenance
 from cellpack.autopack.interface_objects.database_ids import DATABASE_IDS
 import collada
@@ -114,6 +113,7 @@ class simulariumHelper(hostHelper.Helper):
         self.nogui = True
         self.hext = "dae"
         self.max_fiber_length = 0
+        self.plot_data = PlotData()
 
     @staticmethod
     def format_rgb_color(color):
@@ -1373,92 +1373,9 @@ class simulariumHelper(hostHelper.Helper):
             spatial_units=UnitData("nm"),  # nanometers
         )
         converter = TrajectoryConverter(converted_data)
-        # plot_data = ScatterPlotData(
-        #     title="test_plot",
-        #     xaxis_title="concentrations (uM)",
-        #     yaxis_title="time (s)",
-        #     xtrace=np.array(
-        #         [
-        #             0.0,
-        #             1.0,
-        #             2.0,
-        #             3.0,
-        #             4.0,
-        #             5.0,
-        #             6.0,
-        #             7.0,
-        #             8.0,
-        #             9.0,
-        #             3.0,
-        #             4.0,
-        #             3.0,
-        #             7.0,
-        #             5.0,
-        #             3.0,
-        #             6.0,
-        #             5.0,
-        #             2.0,
-        #             4.0,
-        #         ]
-        #     ),
-        #     ytraces={
-        #         "agent1": np.array(
-        #             [
-        #                 0.0,
-        #                 1.0,
-        #                 2.0,
-        #                 3.0,
-        #                 4.0,
-        #                 5.0,
-        #                 6.0,
-        #                 7.0,
-        #                 8.0,
-        #                 9.0,
-        #                 3.0,
-        #                 4.0,
-        #                 3.0,
-        #                 7.0,
-        #                 5.0,
-        #                 3.0,
-        #                 6.0,
-        #                 5.0,
-        #                 2.0,
-        #                 4.0,
-        #             ]
-        #         ),
-        #     },
-        # )
-        plot_data = HistogramPlotData(
-            title="Test Histogram 2",
-            xaxis_title="concentrations (uM)",
-            traces={
-                "agent1": np.array(
-                    [
-                        0.0,
-                        1.0,
-                        2.0,
-                        3.0,
-                        4.0,
-                        5.0,
-                        6.0,
-                        7.0,
-                        8.0,
-                        9.0,
-                        3.0,
-                        4.0,
-                        3.0,
-                        7.0,
-                        5.0,
-                        3.0,
-                        6.0,
-                        5.0,
-                        2.0,
-                        4.0,
-                    ]
-                ),
-            },
-        )
-        converter.add_plot(plot_data, "histogram")
+        plot_list = self.plot_data.plot_list
+        for type, plot in plot_list:
+            converter.add_plot(plot, type)
         converter.save(file_name, False)
         return file_name
 

--- a/cellpack/autopack/upy/simularium/simularium_helper.py
+++ b/cellpack/autopack/upy/simularium/simularium_helper.py
@@ -1372,6 +1372,7 @@ class simulariumHelper(hostHelper.Helper):
             time_units=UnitData("ns"),  # nanoseconds
             spatial_units=UnitData("nm"),  # nanometers
         )
+        converter = TrajectoryConverter(converted_data)
         plot_data = ScatterPlotData(
             title="test_plot",
             xaxis_title="concentrations (uM)",
@@ -1427,9 +1428,8 @@ class simulariumHelper(hostHelper.Helper):
                 ),
             },
         )
-        trajectory_converter = TrajectoryConverter(converted_data)
-        trajectory_converter.add_plot(plot_data, "scatter")
-        trajectory_converter.save(file_name, False)
+        converter.add_plot(plot_data, "scatter")
+        converter.save(file_name)
         return file_name
 
     def raycast(self, **kw):

--- a/cellpack/autopack/writers/__init__.py
+++ b/cellpack/autopack/writers/__init__.py
@@ -188,6 +188,8 @@ class Writer(object):
         is_aggregate = len(seed_to_results_map) > 1
         if is_aggregate:
             result_file_name = f"{env.result_file.split('_seed')[0]}_all"
+        else:
+            result_file_name = f"{env.result_file.split('_seed')[0]}_seed_{list(seed_to_results_map.keys())[0]}"
         file_name = env.helper.writeToFile(
             result_file_name, env.boundingBox, env.name, env.version
         )

--- a/cellpack/bin/pack.py
+++ b/cellpack/bin/pack.py
@@ -48,7 +48,6 @@ def pack(recipe, config_path=None, analysis_config_path=None):
         packing_config_data["save_analyze_result"]
         or packing_config_data["number_of_packings"] > 1
     ):
-        env.saveResult = False
         analyze = Analysis(
             env=env,
             viewer=afviewer,

--- a/cellpack/bin/pack.py
+++ b/cellpack/bin/pack.py
@@ -48,6 +48,7 @@ def pack(recipe, config_path=None, analysis_config_path=None):
         packing_config_data["save_analyze_result"]
         or packing_config_data["number_of_packings"] > 1
     ):
+        env.saveResult = False
         analyze = Analysis(
             env=env,
             viewer=afviewer,


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
closes #254 

Solution
========

- created a class to handle plot data(scatter plots and histograms) and added all plots to one list
- in the function `histogram` within `Analysis.py`, added the logic to insert plot data into result file. Set the argument `add_to_result` to true and set `save_png` to false, by default 
- in `simularium_helper`, added plot data to the trajectory converter and had simularium io process the plot display on the website     

with @meganrm @mogres @ascibisz and Joe

## Type of change
* New feature (non-breaking change which adds functionality)



Steps to Verify:
----------------
1. Pack any recipes with the `save_analyze_result` config set to `true` to see if the plots display next to the result as expected 

Screenshots (optional):
-----------------------
<img width="1404" alt="Screenshot 2024-05-29 at 1 22 15 PM" src="https://github.com/mesoscope/cellpack/assets/91452427/6b62729f-2b5d-45d3-abb2-fcbf8469b3cc">



