### PR TITLE
Adding `grid_file_path` to recipe metadata for uploads 

### DIFF
--- a/cellpack/autopack/loaders/recipe_loader.py
+++ b/cellpack/autopack/loaders/recipe_loader.py
@@ -132,16 +132,6 @@ class RecipeLoader(object):
             format_version = recipe_data["format_version"]
         return format_version
 
-    def get_only_recipe_metadata(self):
-        recipe_meta_data = {
-            "format_version": self.recipe_data["format_version"],
-            "version": self.recipe_data["version"],
-            "name": self.recipe_data["name"],
-            "bounding_box": self.recipe_data["bounding_box"],
-            "composition": {},
-        }
-        return recipe_meta_data
-
     def _migrate_version(self, old_recipe):
         converted = False
         if old_recipe["format_version"] == "1.0":

--- a/cellpack/bin/upload.py
+++ b/cellpack/bin/upload.py
@@ -10,7 +10,7 @@ from cellpack.autopack.loaders.recipe_loader import RecipeLoader
 
 def get_recipe_metadata(loader):
     """
-    Fetches and returns the metadata of the recipe for uploading
+    Extracts and returns essential metadata from a recipe for uploading
     """
     try:
         recipe_meta_data = {

--- a/cellpack/bin/upload.py
+++ b/cellpack/bin/upload.py
@@ -8,6 +8,25 @@ from cellpack.autopack.interface_objects.database_ids import DATABASE_IDS
 from cellpack.autopack.loaders.recipe_loader import RecipeLoader
 
 
+def get_recipe_metadata(loader):
+    """
+    Fetches and returns the metadata of the recipe for uploading
+    """
+    try:
+        recipe_meta_data = {
+            "format_version": loader.recipe_data["format_version"],
+            "version": loader.recipe_data["version"],
+            "name": loader.recipe_data["name"],
+            "bounding_box": loader.recipe_data["bounding_box"],
+            "composition": {},
+        }
+        if "grid_file_path" in loader.recipe_data:
+            recipe_meta_data["grid_file_path"] = loader.recipe_data["grid_file_path"]
+        return recipe_meta_data
+    except KeyError as e:
+        sys.exit(f"Recipe metadata is missing. {e}")
+
+
 def upload(
     recipe_path,
     db_id=DATABASE_IDS.FIREBASE,
@@ -23,7 +42,7 @@ def upload(
         if FirebaseHandler._initialized:
             recipe_loader = RecipeLoader(recipe_path)
             recipe_full_data = recipe_loader._read(resolve_inheritance=False)
-            recipe_meta_data = recipe_loader.get_only_recipe_metadata()
+            recipe_meta_data = get_recipe_metadata(recipe_loader)
             recipe_db_handler = DBUploader(db_handler)
             recipe_db_handler.upload_recipe(recipe_meta_data, recipe_full_data)
         else:


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
closes #266 

Solution
========
What I/we did to solve this problem
- relocated function: removed `get_only_recipe_metadata` from `recipe_loader.py`, and added `get_recipe_metadata` in `upload.py` 
- modified the function to explicitly check for and extract the `grid_file_path` if it exists in recipe data

## Type of change
Please delete options that are not relevant.
* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Upload a recipe that includes the `grid_file_path` to firebase. Run `upload -r cellpack/tests/recipes/v2/test_url_load.json`
2. Verify that the recipe contains all the expected fields. 

Note: At this stage of development, we'll need to delete any existing recipe in firebase before re-uploading a recipe with the same name. Discussions are ongoing about enabling options to overwrite or update existing recipes
