### PR TITLE
Firebase uploader refactor: update multiple compositions in the same region

### DIFF
--- a/cellpack/tests/test_db_uploader.py
+++ b/cellpack/tests/test_db_uploader.py
@@ -104,7 +104,7 @@ def test_upload_compositions():
         "space": {"id": "test_id", "path": "firebase:composition/test_id"},
     }
     assert references_to_update == {
-        "space": {"comp_id": "test_id", "index": "regions.interior", "name": "A"}
+        "space": [{"comp_id": "test_id", "index": "regions.interior", "name": "A"}]
     }
 
 


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
closes #244 


Solution
========
What I/we did to solve this problem
modified `DBUploader` to correctly update composition ids within the same region

## Type of change
Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. upload a recipe that has multiple comps in the same region - `upload -r examples/recipes/v2/anaylsis_b.json`
2. verify the expected `space` structure in Firebase:
<img width="533" alt="Screenshot 2024-06-25 at 3 31 44 PM" src="https://github.com/mesoscope/cellpack/assets/91452427/8f2b8fa3-c295-4741-b20a-cb018d0740d7">

3. (optional) pack this firebase recipe - `pack -r firebase:recipes/analysis_b_v_1.0.0 `, it should run without errors
