### PR TITLE
Feature/support gradient arrays in firebase

### DIFF
--- a/cellpack/autopack/DBRecipeHandler.py
+++ b/cellpack/autopack/DBRecipeHandler.py
@@ -713,10 +713,20 @@ class DBRecipeLoader(object):
         obj_name = obj_data["name"]
         for key, target_dict in CompositionDoc.KEY_TO_DICT_MAPPING.items():
             if key in obj_data:
-                item_name = obj_data[key]["name"]
-                target_dict = grad_dict if key == "gradient" else obj_dict
-                target_dict[item_name] = obj_data[key]
-                obj_dict[obj_name][key] = item_name
+                # single gradient and inherited object
+                if isinstance(obj_data[key], dict):
+                    item_name = obj_data[key]["name"]
+                    target_dict = grad_dict if key == "gradient" else obj_dict
+                    target_dict[item_name] = obj_data[key]
+                    obj_dict[obj_name][key] = item_name
+                # combined gradients
+                elif key == "gradient" and isinstance(obj_data[key], list):
+                    new_grad_list = []
+                    for grad in obj_data[key]:
+                        for name in grad:
+                            grad_dict[name] = grad[name]
+                            new_grad_list.append(name)
+                    obj_dict[obj_name][key] = new_grad_list
         return obj_dict, grad_dict
 
     @staticmethod

--- a/cellpack/autopack/DBRecipeHandler.py
+++ b/cellpack/autopack/DBRecipeHandler.py
@@ -156,9 +156,19 @@ class CompositionDoc(DataDoc):
         Resolve the object data from the local data.
         """
         for key in CompositionDoc.KEY_TO_DICT_MAPPING:
-            if key in object_data and isinstance(object_data[key], str):
-                target_dict = CompositionDoc.KEY_TO_DICT_MAPPING[key]
-                object_data[key] = prep_recipe_data[target_dict][object_data[key]]
+            if key in object_data:
+                # single gradient and inherited object
+                if isinstance(object_data[key], str):
+                    target_dict = CompositionDoc.KEY_TO_DICT_MAPPING[key]
+                    object_data[key] = prep_recipe_data[target_dict][object_data[key]]
+                # combined gradients
+                elif isinstance(object_data[key], list):
+                    new_grad_list = []
+                    for grad in object_data[key]:
+                        new_grad_list.append(
+                            {grad: prep_recipe_data["gradients"][grad]}
+                        )
+                    object_data[key] = new_grad_list
 
     def resolve_local_regions(self, local_data, recipe_data, db):
         """

--- a/cellpack/autopack/DBRecipeHandler.py
+++ b/cellpack/autopack/DBRecipeHandler.py
@@ -86,8 +86,15 @@ class CompositionDoc(DataDoc):
     @staticmethod
     def get_reference_in_obj(downloaded_data, db):
         for key in CompositionDoc.KEY_TO_DICT_MAPPING:
-            if key in downloaded_data and db.is_reference(downloaded_data[key]):
-                downloaded_data[key], _ = db.get_doc_by_ref(downloaded_data[key])
+            if key in downloaded_data:
+                # single gradient and inherited object
+                if db.is_reference(downloaded_data[key]):
+                    downloaded_data[key], _ = db.get_doc_by_ref(downloaded_data[key])
+                # combined gradients
+                elif isinstance(downloaded_data[key], list):
+                    for gradient in downloaded_data[key]:
+                        for gradient_name, path in gradient.items():
+                            gradient[gradient_name], _ = db.get_doc_by_ref(path)
 
     @staticmethod
     def get_reference_data(key_or_dict, db):

--- a/cellpack/autopack/DBRecipeHandler.py
+++ b/cellpack/autopack/DBRecipeHandler.py
@@ -152,7 +152,7 @@ class CompositionDoc(DataDoc):
             prep_recipe_data["gradients"] = gradient_dict
 
     @staticmethod
-    def create_combined_gradient_list(key, obj_data, prep_data):
+    def resolve_combined_gradient(key, obj_data, prep_data):
         """
         When the gradients are combined, fetch and replace gradient data in a list.
         key --> the key in the object data that we want to modify its value
@@ -176,7 +176,7 @@ class CompositionDoc(DataDoc):
                     object_data[key] = prep_recipe_data[target_dict][object_data[key]]
                 # combined gradients
                 elif isinstance(object_data[key], list):
-                    self.create_combined_gradient_list(
+                    self.resolve_combined_gradient(
                         key, object_data, prep_recipe_data["gradients"]
                     )
 
@@ -516,7 +516,7 @@ class DBUploader(object):
                 obj_data[obj_name]["gradient"] = self.grad_to_path_map[grad_name]
             # combined gradients
             elif isinstance(obj_data[obj_name]["gradient"], list):
-                CompositionDoc.create_combined_gradient_list(
+                CompositionDoc.resolve_combined_gradient(
                     "gradient", obj_data[obj_name], self.grad_to_path_map
                 )
         object_doc = ObjectDoc(name=obj_name, settings=obj_data[obj_name])

--- a/cellpack/autopack/DBRecipeHandler.py
+++ b/cellpack/autopack/DBRecipeHandler.py
@@ -483,8 +483,16 @@ class DBUploader(object):
     def upload_single_object(self, obj_name, obj_data):
         # replace gradient name with path to check if gradient exists in db
         if "gradient" in obj_data[obj_name]:
-            grad_name = obj_data[obj_name]["gradient"]
-            obj_data[obj_name]["gradient"] = self.grad_to_path_map[grad_name]
+            # single gradient
+            if isinstance(obj_data[obj_name]["gradient"], str):
+                grad_name = obj_data[obj_name]["gradient"]
+                obj_data[obj_name]["gradient"] = self.grad_to_path_map[grad_name]
+            # combined gradients
+            elif isinstance(obj_data[obj_name]["gradient"], list):
+                new_grad_list = []
+                for grad in obj_data[obj_name]["gradient"]:
+                    new_grad_list.append({grad: self.grad_to_path_map[grad]})
+                obj_data[obj_name]["gradient"] = new_grad_list
         object_doc = ObjectDoc(name=obj_name, settings=obj_data[obj_name])
         _, doc_id = object_doc.should_write(self.db)
         if doc_id:


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
closes #273 

Solution
========
When gradient is a list of gradient names, e.g `"gradient": ["X_gradient","Y_gradient"]`, we need to add additional steps to our current upload+download system.  

- when uploading: added handling for gradient lists to record each reference of gradient in the list
- for duplicate check: resolve each gradient data in the list correctly and consistently 
- when downloading: prepared data to recognize gradient lists and fetch each gradient data correctly 

Note: After adding logic to detect, unpack and resolve combined gradients in the corresponding steps of the process, our system can now upload and download the current test recipes in all contexts. I did notice an odd behavior (not breaking anything) with the recipe loader automatically adding a default `representation` to each object when downloading recipes from firebase, will write another issue to address this.   


## Type of change
Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Ensure your database doesn't contain any `test_combined_gradient.json` related data. Delete them if they exist 
2. Upload recipe to firebase: run `upload -r cellpack/tests/recipes/v2/test_combined_gradient.json`
3. Pack the firebase recipe: run `pack firebase:recipes/test_combined_gradient_v_1.0.0`
4. If followed step 1, you should be able to upload and download without issues. (but please let me know if you do encounter any)
