### PR TITLE
Feature/aws cli in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+### Build image ###
+FROM python:3.10
+
+WORKDIR /cellpack
+COPY . /cellpack
+
+RUN python -m pip install --upgrade pip --root-user-action=ignore
+RUN python -m pip install . --root-user-action=ignore
+
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN ["chmod", "+x", "/usr/local/bin/docker-entrypoint.sh"]
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,4 @@ RUN apt-get update && apt-get install -y awscli
 
 COPY docker-entrypoint.sh /usr/local/bin/
 RUN ["chmod", "+x", "/usr/local/bin/docker-entrypoint.sh"]
-
-
-# Copy and set permissions for the AWS configure script
-COPY configure-aws.sh /usr/local/bin/
-RUN ["chmod", "+x", "/usr/local/bin/configure-aws.sh"]
-
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,15 @@ COPY . /cellpack
 RUN python -m pip install --upgrade pip --root-user-action=ignore
 RUN python -m pip install . --root-user-action=ignore
 
+# Install AWS CLI
+RUN apt-get update && apt-get install -y awscli
+
 COPY docker-entrypoint.sh /usr/local/bin/
 RUN ["chmod", "+x", "/usr/local/bin/docker-entrypoint.sh"]
+
+
+# Copy and set permissions for the AWS configure script
+COPY configure-aws.sh /usr/local/bin/
+RUN ["chmod", "+x", "/usr/local/bin/configure-aws.sh"]
+
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -89,15 +89,23 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for information related to developing the
      * Create a Firebase project in test mode with your google account, select `firebase_admin` as the SDK. [Firebase Firestore tutorial](https://firebase.google.com/docs/firestore)
      * Generate a new private key by navigating to "Project settings">"Service account" in the project's dashboard.
    * For staging database:
-       * Reach out to the code owner for the necessary credentials.
-       * Set up an `.env` file as instructed.
+       * Obtain credentials:
+          * Reach out to the code owner for the necessary credentials.
+       * Configure the environment variables:
+          * Create a `.env` file in the root directory.
+          * Populate the `.env` file with the following variables:
+           ```
+               FIREBASE_TOKEN=KEY_JSON_FILE["private_key"]
+               FIREBASE_EMAIL=KEY_JSON_FILE["client_email"]
+           ```
+          note: `KEY_JSON_FILE` is the content of the private key JSON file generated in the staging Firebase.
 
 ### Docker
 
 1. Install [docker](https://docs.docker.com/v17.09/engine/installation/)
 2. Clone the repository locally, if you haven't already: `git clone https://github.com/mesoscope/cellpack.git`
 3. Ensure that you have valid AWS access key and secret to access the `cellpack-results` S3 bucket, usually stored in a `~/.aws/credentials` file. 
-4. To build the container, run: `docker build -t [CONTAINER-NAME] .`
+4. To build the container, run: `docker build -t [CONTAINER-NAME] .` Rebuild the container if new files are added or changes are made to the codebase.
 5. To run packings in the container, run: `docker run -v ~/.aws:/root/.aws -e recipe=examples/recipes/v2/one_sphere.json -e config=examples/packing-configs/run.json [CONTAINER-NAME]`
 6. Verify that the packing results are saved in the `cellpack-results` S3 bucket. You should see a botocore logging message indicating that the credentials were successfully loaded.
 

--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for information related to developing the
 1. Install [docker](https://docs.docker.com/v17.09/engine/installation/)
 2. Clone the repository locally, if you haven't already: `git clone https://github.com/mesoscope/cellpack.git`
 3. Ensure that you have valid AWS access key and secret to access the `cellpack-results` S3 bucket, usually stored in a `~/.aws/credentials` file. 
-4. To build the container, run: `docker build -t cellpack_image .` Include `--build-arg local=True` if running locally, omit if running on an EC2 instance connected to EFS volume
-5. To run packings in the container, run: `docker run -v ~/.aws:/root/.aws -e recipe=examples/recipes/v2/one_sphere.json -e config=examples/packing-configs/run.json cellpack_image`
+4. To build the container, run: `docker build -t [CONTAINER-NAME] .`
+5. To run packings in the container, run: `docker run -v ~/.aws:/root/.aws -e recipe=examples/recipes/v2/one_sphere.json -e config=examples/packing-configs/run.json [CONTAINER-NAME]`
 6. Verify that the packing results are saved in the `cellpack-results` S3 bucket. You should see a botocore logging message indicating that the credentials were successfully loaded.
 
 **MIT license**

--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for information related to developing the
 1. Install [docker](https://docs.docker.com/v17.09/engine/installation/)
 2. Clone the repository locally, if you haven't already: `git clone https://github.com/mesoscope/cellpack.git`
 3. Ensure that you have valid AWS access key and secret to access the `cellpack-results` S3 bucket, usually stored in a `~/.aws/credentials` file. 
-4. To build the container, run: `sudo docker build -t cellpack_image .` Include `--build-arg local=True` if running locally, omit if running on an EC2 instance connected to EFS volume
-5. To run packings in the container, run: `sudo docker run -v ~/.aws:/root/.aws -e recipe=examples/recipes/v2/one_sphere.json -e config=examples/packing-configs/run.json cellpack_image`
+4. To build the container, run: `docker build -t cellpack_image .` Include `--build-arg local=True` if running locally, omit if running on an EC2 instance connected to EFS volume
+5. To run packings in the container, run: `docker run -v ~/.aws:/root/.aws -e recipe=examples/recipes/v2/one_sphere.json -e config=examples/packing-configs/run.json cellpack_image`
 6. Verify that the packing results are saved in the `cellpack-results` S3 bucket. You should see a botocore logging message indicating that the credentials were successfully loaded.
 
 **MIT license**

--- a/README.md
+++ b/README.md
@@ -92,5 +92,14 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for information related to developing the
        * Reach out to the code owner for the necessary credentials.
        * Set up an `.env` file as instructed.
 
+### Docker
+
+1. Install [docker](https://docs.docker.com/v17.09/engine/installation/)
+2. Clone the repository locally, if you haven't already: `git clone https://github.com/mesoscope/cellpack.git`
+3. Ensure that you have valid AWS access key and secret to access the `cellpack-results` S3 bucket, usually stored in a `~/.aws/credentials` file. 
+4. To build the container, run: `sudo docker build -t cellpack_image .` Include `--build-arg local=True` if running locally, omit if running on an EC2 instance connected to EFS volume
+5. To run packings in the container, run: `sudo docker run -v ~/.aws:/root/.aws -e recipe=examples/recipes/v2/one_sphere.json -e config=examples/packing-configs/run.json cellpack_image`
+6. Verify that the packing results are saved in the `cellpack-results` S3 bucket. You should see a botocore logging message indicating that the credentials were successfully loaded.
+
 **MIT license**
 

--- a/configure-aws.sh
+++ b/configure-aws.sh
@@ -1,4 +1,0 @@
-# Configure AWS CLI
-aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID
-aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY
-aws configure set default.region $AWS_DEFAULT_REGION

--- a/configure-aws.sh
+++ b/configure-aws.sh
@@ -1,0 +1,4 @@
+# Configure AWS CLI
+aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID
+aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY
+aws configure set default.region $AWS_DEFAULT_REGION

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -e
+
+# if [ -z "$recipe" ]; then
+#     echo "Required recipe parameter is missing, please include recipe in Docker run script, ie: -e r=path/to/recipe"
+#     exit 
+# fi
+
+# if [ -z "$config" ]; then
+#     echo "Required config parameter is missing, please include packing config in Docker run script, ie: -e c=path/to/config"
+#     exit 
+# fi
+
+cd /cellpack
+# pack -r ${recipe} -c ${config}
+pack -r examples/recipes/v2/one_sphere.json -c examples/packing-configs/run.json

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,9 +10,6 @@
 #     exit 
 # fi
 
-# Configure AWS CLI
-/usr/local/bin/configure-aws.sh
-
 cd /cellpack
 # pack -r ${recipe} -c ${config}
 pack -r examples/recipes/v2/one_sphere.json -c examples/packing-configs/run.json

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,6 +10,9 @@
 #     exit 
 # fi
 
+# Configure AWS CLI
+/usr/local/bin/configure-aws.sh
+
 cd /cellpack
 # pack -r ${recipe} -c ${config}
 pack -r examples/recipes/v2/one_sphere.json -c examples/packing-configs/run.json


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
closes #279 

Solution
========
What I/we did to solve this problem

- Followed the steps in the ticket. We successfully accessed S3 bucket and stored result files and metadata within the Docker container 
- Updated Readme 

Note: We saw two informational warnings while running the packings. These will be addressed in a separate PR.  

with @ascibisz 

## Type of change
Please delete options that are not relevant.
* New feature (non-breaking change which adds functionality)


Steps to Verify:
----------------
1. Make sure you have Docker installed locally, and access to cellPACK S3 bucket
2. Build the container: `docker build -t [CONTAINER-NAME] . `
3. Mount AWS credentials into container and run test packing: `docker run -v ~/.aws:/root/.aws -e recipe=examples/recipes/v2/one_sphere.json -e config=examples/packing-configs/run.json [CONTAINER-NAME]` 

You should see output similar to the following in your terminal:
<img width="1231" alt="Screenshot 2024-08-01 at 2 21 00 PM" src="https://github.com/user-attachments/assets/f0b2f186-7cc7-4eed-be1a-a0a99880b443">

4. Check metadata is stored in Firebase: 
<img width="1260" alt="Screenshot 2024-08-01 at 2 22 57 PM" src="https://github.com/user-attachments/assets/9f846684-dd55-4c23-9ab9-43564d7a722d">




