### PR TITLE
Update workflow to access aws for dependabot 

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -1,10 +1,10 @@
 name: Analyze
 
-on: 
-  push:
-    branches:
-      - main
-  pull_request:
+on:
+    push:
+        branches:
+            - feature/dependabot-creds
+    pull_request:
 
 jobs:
     Analyze:
@@ -45,15 +45,19 @@ jobs:
         needs: [Analyze]
         steps:
             - uses: actions/checkout@v4
+
+            - name: Print GitHub Actor
+              run: echo ${{ github.actor }}
+
             - name: Configure AWS credentials
-              if: github.actor == 'dependabot[bot]'
+              if: ${{ github.actor == 'dependabot[bot]' }}
               uses: aws-actions/configure-aws-credentials@v4
               with:
-                aws-access-key-id: ${{ secrets.DEPENDABOT_AWS_ACCESS_KEY_ID }}
-                aws-secret-access-key: ${{ secrets.DEPENDABOT_AWS_SECRET_ACCESS_KEY }}
-                aws-region: us-west-2
+                  aws-access-key-id: ${{ secrets.DEPENDABOT_AWS_ACCESS_KEY_ID }}
+                  aws-secret-access-key: ${{ secrets.DEPENDABOT_AWS_SECRET_ACCESS_KEY }}
+                  aws-region: us-west-2
             - name: Configure AWS credentials
-              if: github.actor != 'dependabot[bot]'
+              if: ${{ github.actor != 'dependabot[bot]' }}
               uses: aws-actions/configure-aws-credentials@v4
               with:
                   aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -3,7 +3,7 @@ name: Analyze
 on:
     push:
         branches:
-            - feature/dependabot-creds
+            - main
     pull_request:
 
 jobs:
@@ -45,10 +45,6 @@ jobs:
         needs: [Analyze]
         steps:
             - uses: actions/checkout@v4
-
-            - name: Print GitHub Actor
-              run: echo ${{ github.actor }}
-
             - name: Configure AWS credentials
               if: ${{ github.actor == 'dependabot[bot]' }}
               uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -45,7 +45,7 @@ jobs:
         needs: [Analyze]
         steps:
             - uses: actions/checkout@v4
-            - name: Configure AWS credentials
+            - name: Configure AWS credentials for dependabot
               if: ${{ github.actor == 'dependabot[bot]' }}
               uses: aws-actions/configure-aws-credentials@v4
               with:

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -46,6 +46,14 @@ jobs:
         steps:
             - uses: actions/checkout@v4
             - name: Configure AWS credentials
+              if: github.actor == 'dependabot[bot]'
+              uses: aws-actions/configure-aws-credentials@v4
+              with:
+                aws-access-key-id: ${{ secrets.DEPENDABOT_AWS_ACCESS_KEY_ID }}
+                aws-secret-access-key: ${{ secrets.DEPENDABOT_AWS_SECRET_ACCESS_KEY }}
+                aws-region: us-west-2
+            - name: Configure AWS credentials
+              if: github.actor != 'dependabot[bot]'
               uses: aws-actions/configure-aws-credentials@v4
               with:
                   aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
the `analyze` workflow fails to run for dependabot PRs due to credential errors, [example](https://github.com/mesoscope/cellpack/actions/runs/10190792433/job/28191115040?pr=278)

Solution
========
What I/we did to solve this problem
- added `DEPENDABOT_AWS_ACCESS_KEY_ID` and `DEPENDABOT_AWS_SECRET_ACCESS_KEY` to dependabot secrets 
- updated `analyze` workflow to handle aws access for dependabot PRs 

Note: I tested the workflow syntax on this branch but wasn't able to test dependabot PRs until we merge the changes to `main` and re-run the open dependabot pr for further testing.

## Type of change
Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)

