### PR TITLE
Fix action authentication error: add a new PAT to dependabot secrets 

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -4,6 +4,7 @@ on:
     push:
         branches:
             - main
+            - fix/*
     pull_request:
 
 jobs:
@@ -63,7 +64,15 @@ jobs:
             - name: Copy files to results bucket
               run: aws s3 cp ./results s3://cellpack-results/${{  github.ref_name  }}/ --recursive --acl public-read
             - uses: iterative/setup-cml@v1
-            - name: Update comment
+            - name: Update comment for dependabot
+              if: ${{ github.actor == 'dependabot[bot]' }}
+              env:
+                  REPO_TOKEN: ${{ secrets.DEPENDABOT_TOKEN }}
+              run: |
+                  cml comment update --watermark-title="{workflow} report" ./results/analysis_report.md --target=pr
+                  cat ./results/analysis_report.md
+            - name: Update comment for PR
+              if: ${{ github.actor != 'dependabot[bot]' }}
               env:
                   REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -4,7 +4,6 @@ on:
     push:
         branches:
             - main
-            - fix/*
     pull_request:
 
 jobs:


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
The `Comment` job for Dependabot PRs is failing because Dependabot doesn't have access to regular repo secrets including `GITHUB_TOKEN`.

Here is the [error](https://github.com/mesoscope/cellpack/actions/runs/11132247372/job/30935752851?pr=291)

Solution
========
What I/we did to solve this problem
Created a separate PAT in dependabot secrets that provides equivalent permissions to `GITHUB_TOKEN`. 

Will rebase and rerun #291 to verify the changes after this pull request is merged.

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

