### PR TITLE
Fix documentation github action

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev", "lint", "setup", "test"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:f81b25160dd592b2e1afae5cb560b1fb0d0c7704e4a912e7508a435f836dc09c"
+content_hash = "sha256:2194c43d8a21a8809e548485e85f3d764c57025f6fa60a9311ea53ea37634269"
 
 [[metadata.targets]]
 requires_python = "==3.9.*"
@@ -615,7 +615,7 @@ name = "docutils"
 version = "0.20.1"
 requires_python = ">=3.7"
 summary = "Docutils -- Python Documentation Utilities"
-groups = ["dev"]
+groups = ["dev", "lint"]
 files = [
     {file = "docutils-0.20.1-py3-none-any.whl", hash = "sha256:96f387a2c5562db4476f09f13bbab2192e764cac08ebbf3a34a95d9b1e4a59d6"},
     {file = "docutils-0.20.1.tar.gz", hash = "sha256:f08a4e276c3a1583a86dce3e34aba3fe04d02bba2dd51ed16106244e8a923e3b"},
@@ -2399,6 +2399,17 @@ files = [
     {file = "scipy-1.13.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a014c2b3697bde71724244f63de2476925596c24285c7a637364761f8710891c"},
     {file = "scipy-1.13.1-cp39-cp39-win_amd64.whl", hash = "sha256:392e4ec766654852c25ebad4f64e4e584cf19820b980bc04960bca0b0cd6eaa2"},
     {file = "scipy-1.13.1.tar.gz", hash = "sha256:095a87a0312b08dfd6a6155cbbd310a8c51800fc931b8c0b84003014b874ed3c"},
+]
+
+[[package]]
+name = "setuptools"
+version = "75.8.0"
+requires_python = ">=3.9"
+summary = "Easily download, build, install, upgrade, and uninstall Python packages"
+groups = ["setup"]
+files = [
+    {file = "setuptools-75.8.0-py3-none-any.whl", hash = "sha256:e3982f444617239225d675215d51f6ba05f845d4eec313da4418fdbb56fb27e3"},
+    {file = "setuptools-75.8.0.tar.gz", hash = "sha256:c5afc8f407c626b8313a86e10311dd3f661c6cd9c09d4bf8c15c0e11f9f2b0e6"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,10 @@ dev = [
     "bumpver>=2024.1130",
     "docutils<0.21,>=0.18.1",
 ]
-setup = ["pytest-runner>=6.0.1"]
+setup = [
+    "pytest-runner>=6.0.1",
+    "setuptools>=75.8.0",
+]
 test = ["pytest-cov>=6.0.0", "pytest-raises>=0.11", "pytest>=8.3.4"]
 lint = [
     "black>=24.10.0",


### PR DESCRIPTION
Problem
=======
The github action for documentation fails due to missing `pkg_resources` package.

Solution
========
Add setuptools to requirements. (Note, this is a workaround and `pkg_resources` is deprecated in python 3.12)

## Type of change
* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. Merge PR into main branch
2. Github action for documentations should run automatically
