### PR TITLE
Fix/upload nested object

### DIFF
--- a/cellpack/autopack/DBRecipeHandler.py
+++ b/cellpack/autopack/DBRecipeHandler.py
@@ -55,7 +55,13 @@ class CompositionDoc(DataDoc):
     """
 
     SHALLOW_MATCH = ["object", "count", "molarity"]
-    DEFAULT_VALUES = {"object": None, "count": None, "regions": {}, "molarity": None}
+    DEFAULT_VALUES = {
+        "object": None,
+        "count": None,
+        "regions": {},
+        "molarity": None,
+        "priority": None,
+    }
     KEY_TO_DICT_MAPPING = {"gradient": "gradients", "inherit": "objects"}
 
     def __init__(
@@ -65,6 +71,7 @@ class CompositionDoc(DataDoc):
         count=None,
         regions=None,
         molarity=None,
+        priority=None,
         object=None,
     ):
         super().__init__()
@@ -72,6 +79,7 @@ class CompositionDoc(DataDoc):
         self.object = object_key or object
         self.count = count
         self.molarity = molarity
+        self.priority = priority
         self.regions = regions or {}
 
     def as_dict(self):
@@ -80,6 +88,7 @@ class CompositionDoc(DataDoc):
         data["object"] = self.object
         data["count"] = self.count
         data["molarity"] = self.molarity
+        data["priority"] = self.priority
         data["regions"] = self.regions
         return data
 
@@ -223,12 +232,13 @@ class CompositionDoc(DataDoc):
         upload_order.reverse()
         return upload_order
 
-    def replace_region_references(self, composition_data):
+    @staticmethod
+    def replace_region_references(uploader, composition_data):
         """
         Replaces composition references with paths in the database.
         """
         if "object" in composition_data and DataDoc.is_key(composition_data["object"]):
-            composition_data["object"] = self.objects_to_path_map.get(
+            composition_data["object"] = uploader.objects_to_path_map.get(
                 composition_data["object"]
             )
 
@@ -239,12 +249,11 @@ class CompositionDoc(DataDoc):
                 for index, item in enumerate(composition_data["regions"][region_name]):
                     if isinstance(item, str):
                         composition_data["regions"][region_name][index] = (
-                            self.comp_to_path_map.get(item)
+                            uploader.comp_to_path_map.get(item)
                         )
                     elif isinstance(item, dict):
                         # process nested regions recursively
-                        if "regions" in item and item["regions"]:
-                            self.replace_region_references(item)
+                        CompositionDoc.replace_region_references(uploader, item)
         return composition_data
 
 
@@ -458,6 +467,7 @@ class DBUploader(object):
                 count=comp_data["count"],
                 regions=comp_data["regions"],
                 molarity=comp_data["molarity"],
+                priority=comp_data["priority"],
             )
 
             comp_ready_for_db = comp_doc.as_dict()
@@ -545,6 +555,7 @@ class DBRecipeLoader(object):
                             count=None,
                             regions={},
                             molarity=None,
+                            priority=None,
                         )
                         composition_data, _ = comp_doc.get_reference_data(
                             ref_link, self.db

--- a/cellpack/autopack/DBRecipeHandler.py
+++ b/cellpack/autopack/DBRecipeHandler.py
@@ -54,7 +54,6 @@ class CompositionDoc(DataDoc):
     Declares required attributes for comps in the constructor, set default values.
     """
 
-    SHALLOW_MATCH = ["object", "count", "molarity"]
     DEFAULT_VALUES = {
         "object": None,
         "count": None,

--- a/cellpack/tests/test_comp_doc.py
+++ b/cellpack/tests/test_comp_doc.py
@@ -11,6 +11,7 @@ def test_composition_doc_as_dict():
         object={"test_key": "test_value"},
         regions={},
         molarity=None,
+        priority=None,
     )
     expected_dict = {
         "name": "test",
@@ -18,6 +19,7 @@ def test_composition_doc_as_dict():
         "object": {"test_key": "test_value"},
         "regions": {},
         "molarity": None,
+        "priority": None,
     }
     assert composition_doc.as_dict() == expected_dict
 
@@ -29,6 +31,7 @@ def test_get_reference_data_with_dict():
         object={"object": "firebase:objects/test_id"},
         regions={},
         molarity=None,
+        priority=None,
     )
     downloaded_data, key = composition_db_doc.get_reference_data(
         composition_db_doc.as_dict()["object"], mock_db
@@ -44,6 +47,7 @@ def test_get_reference_data_with_key():
         object="firebase:objects/test_id",
         regions={},
         molarity=None,
+        priority=None,
     )
     downloaded_data, key = composition_db_doc.get_reference_data(
         composition_db_doc.as_dict()["object"], mock_db
@@ -59,6 +63,7 @@ def test_get_reference_data_with_none():
         object=None,
         regions={},
         molarity=None,
+        priority=None,
     )
     downloaded_data, key = composition_db_doc.get_reference_data(
         composition_db_doc.as_dict()["object"], mock_db
@@ -79,12 +84,14 @@ def test_resolve_db_regions():
             ]
         },
         molarity=None,
+        priority=None,
     )
     resolved_data = {
         "name": "test",
         "object": None,
         "count": 1,
         "molarity": None,
+        "priority": None,
         "regions": {
             "test_region_name": [
                 {"test": "downloaded_data"},
@@ -103,12 +110,14 @@ def test_resolve_db_regions_with_none():
         object=None,
         regions=None,
         molarity=None,
+        priority=None,
     )
     resolved_data = {
         "name": "test",
         "object": None,
         "count": 1,
         "molarity": None,
+        "priority": None,
         "regions": {},
     }
     composition_db_doc.resolve_db_regions(composition_db_doc.as_dict(), mock_db)
@@ -122,6 +131,7 @@ def test_build_dependency_graph():
         object=None,
         regions=None,
         molarity=None,
+        priority=None,
     )
     compositions = {
         "space": {"regions": {"interior": ["A"]}},
@@ -138,6 +148,7 @@ def test_build_dependency_graph_with_complex_compositions():
         object=None,
         regions=None,
         molarity=None,
+        priority=None,
     )
     complex_compositions = {
         "space": {"regions": {"interior": ["tree", "A", "B", "C"]}},
@@ -178,6 +189,7 @@ def test_comp_upload_order():
         object=None,
         regions=None,
         molarity=None,
+        priority=None,
     )
     compositions = {
         "space": {"regions": {"interior": ["A"]}},

--- a/cellpack/tests/test_comp_doc.py
+++ b/cellpack/tests/test_comp_doc.py
@@ -110,14 +110,14 @@ def test_resolve_db_regions_with_none():
         object=None,
         regions=None,
         molarity=None,
-        priority=None,
+        priority=-1,
     )
     resolved_data = {
         "name": "test",
         "object": None,
         "count": 1,
         "molarity": None,
-        "priority": None,
+        "priority": -1,
         "regions": {},
     }
     composition_db_doc.resolve_db_regions(composition_db_doc.as_dict(), mock_db)
@@ -131,7 +131,7 @@ def test_build_dependency_graph():
         object=None,
         regions=None,
         molarity=None,
-        priority=None,
+        priority=-1,
     )
     compositions = {
         "space": {"regions": {"interior": ["A"]}},


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
A quick fix for remote recipes.
Alli and I were testing more recipes with the uploading system and found two bugs:
- `priority` is not being uploaded to composition documents
- nested object in composition is not being replaced by its reference  

Solution
========
What I/we did to solve this problem
- added `priority` to default values in compost ion
- fixed the `replace_region_references` function to resolve nested region references    
- update unittests 
with @Alli

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)



Steps to Verify:
----------------
1. Upload a recipe to Firebase and check the data

