### PR TITLE
Pack firebase configs

### DIFF
--- a/cellpack/autopack/DBRecipeHandler.py
+++ b/cellpack/autopack/DBRecipeHandler.py
@@ -8,6 +8,7 @@ import hashlib
 import json
 import requests
 
+from cellpack.autopack.interface_objects.database_ids import DATABASE_IDS
 from cellpack.autopack.utils import deep_merge
 
 
@@ -536,6 +537,17 @@ class DBRecipeLoader(object):
 
     def __init__(self, db_handler):
         self.db = db_handler
+
+    def read_config(self, config_path):
+        """
+        Read the config data from the database.
+        """
+        collection, id = self.db.get_collection_id_from_path(config_path)
+        config_data, _ = self.db.get_doc_by_id(collection, id)
+        if config_data:
+            return config_data
+        else:
+            raise ValueError(f"Config not found at path: {config_path}")
 
     def prep_db_doc_for_download(self, db_doc):
         """

--- a/cellpack/autopack/DBRecipeHandler.py
+++ b/cellpack/autopack/DBRecipeHandler.py
@@ -8,7 +8,6 @@ import hashlib
 import json
 import requests
 
-from cellpack.autopack.interface_objects.database_ids import DATABASE_IDS
 from cellpack.autopack.utils import deep_merge
 
 

--- a/cellpack/autopack/DBRecipeHandler.py
+++ b/cellpack/autopack/DBRecipeHandler.py
@@ -508,7 +508,11 @@ class DBUploader(object):
         Upload the config data to the database.
         """
         config_data["source_path"] = source_path
-        self.upload_data("configs", config_data)
+        id, doc_path = self.upload_data("configs", config_data)
+        print(f"Config uploaded to {doc_path}")
+        # update the config data with the firebase doc path
+        config_data["config_path"] = doc_path
+        self.db.update_doc("configs", id, config_data)
         return
 
     def upload_result_metadata(self, file_name, url):

--- a/cellpack/autopack/DBRecipeHandler.py
+++ b/cellpack/autopack/DBRecipeHandler.py
@@ -503,6 +503,14 @@ class DBUploader(object):
         recipe_to_save["recipe_path"] = self.db.create_path("recipes", recipe_id)
         self.upload_data("recipes", recipe_to_save, recipe_id)
 
+    def upload_config(self, config_data, source_path):
+        """
+        Upload the config data to the database.
+        """
+        config_data["source_path"] = source_path
+        self.upload_data("configs", config_data)
+        return
+
     def upload_result_metadata(self, file_name, url):
         """
         Upload the metadata of the result file to the database.

--- a/cellpack/autopack/FirebaseHandler.py
+++ b/cellpack/autopack/FirebaseHandler.py
@@ -185,7 +185,7 @@ class FirebaseHandler(object):
     def update_doc(self, collection, id, data):
         doc_ref = self.db.collection(collection).document(id)
         doc_ref.update(data)
-        logging.info(f"successfully updated to path: {doc_ref.path}")
+        logging.info(f"successfully updated doc: {id}")
         return doc_ref
 
     @staticmethod

--- a/cellpack/autopack/__init__.py
+++ b/cellpack/autopack/__init__.py
@@ -395,32 +395,25 @@ def read_text_file(filename, destination="", cache="collisionTrees", force=None)
 def load_file(filename, destination="", cache="geometries", force=None):
     if is_remote_path(filename):
         database_name, file_path = convert_db_shortname_to_url(filename)
-        # command example: `pack -r firebase:recipes/[FIREBASE-RECIPE-ID] -c [CONFIG-FILE-PATH]`
-        if database_name == "firebase":
-            db = DATABASE_IDS.handlers().get(database_name)
-            initialize_db = db()
-            if not initialize_db._initialized:
-                readme_url = "https://github.com/mesoscope/cellpack?tab=readme-ov-file#introduction-to-remote-databases"
-                sys.exit(
-                    f"The selected database is not initialized. Please set up Firebase credentials to pack remote recipes. Refer to the instructions at {readme_url}"
-                )
-            db_handler = DBRecipeLoader(initialize_db)
-            db_handler.validate_input_recipe_path(filename)
-            recipe_id = file_path.split("/")[-1]
-            db_doc, _ = db_handler.collect_docs_by_id(
-                collection="recipes", id=recipe_id
+        db = DATABASE_IDS.handlers().get(database_name)
+        initialize_db = db()
+
+        if not initialize_db._initialized:
+            readme_url = "https://github.com/mesoscope/cellpack?tab=readme-ov-file#introduction-to-remote-databases"
+            sys.exit(
+                f"The selected database: {database_name} is not initialized. Please set up credentials to pack remote recipes. Refer to the instructions at {readme_url}"
             )
-            downloaded_recipe_data = db_handler.prep_db_doc_for_download(db_doc)
-            return downloaded_recipe_data, database_name
-        else:
-            local_file_path = get_local_file_location(
-                file_path, destination=destination, cache=cache, force=force
-            )
+        db_handler = DBRecipeLoader(initialize_db)
+        db_handler.validate_input_recipe_path(filename)
+        recipe_id = file_path.split("/")[-1]
+        db_doc, _ = db_handler.collect_docs_by_id(collection="recipes", id=recipe_id)
+        downloaded_recipe_data = db_handler.prep_db_doc_for_download(db_doc)
+        return downloaded_recipe_data, database_name
     else:
         local_file_path = get_local_file_location(
             filename, destination=destination, cache=cache, force=force
         )
-    return json.load(open(local_file_path, "r")), None
+        return json.load(open(local_file_path, "r")), None
 
 
 def fixPath(adict):  # , k, v):

--- a/cellpack/autopack/interface_objects/default_values.py
+++ b/cellpack/autopack/interface_objects/default_values.py
@@ -20,4 +20,5 @@ default_firebase_collection_names = [
     "gradients",
     "recipes",
     "results",
+    "configs",
 ]

--- a/cellpack/bin/upload.py
+++ b/cellpack/bin/upload.py
@@ -5,6 +5,7 @@ from cellpack.autopack.FirebaseHandler import FirebaseHandler
 from cellpack.autopack.DBRecipeHandler import DBUploader, DBMaintenance
 
 from cellpack.autopack.interface_objects.database_ids import DATABASE_IDS
+from cellpack.autopack.loaders.config_loader import ConfigLoader
 from cellpack.autopack.loaders.recipe_loader import RecipeLoader
 
 
@@ -28,7 +29,8 @@ def get_recipe_metadata(loader):
 
 
 def upload(
-    recipe_path,
+    recipe_path=None,
+    config_path=None,
     db_id=DATABASE_IDS.FIREBASE,
 ):
     """
@@ -40,11 +42,16 @@ def upload(
         # fetch the service key json file
         db_handler = FirebaseHandler()
         if FirebaseHandler._initialized:
-            recipe_loader = RecipeLoader(recipe_path)
-            recipe_full_data = recipe_loader._read(resolve_inheritance=False)
-            recipe_meta_data = get_recipe_metadata(recipe_loader)
-            recipe_db_handler = DBUploader(db_handler)
-            recipe_db_handler.upload_recipe(recipe_meta_data, recipe_full_data)
+            db_handler = DBUploader(db_handler)
+            if recipe_path:
+                recipe_loader = RecipeLoader(recipe_path)
+                recipe_full_data = recipe_loader._read(resolve_inheritance=False)
+                recipe_meta_data = get_recipe_metadata(recipe_loader)
+                db_handler.upload_recipe(recipe_meta_data, recipe_full_data)
+            if config_path:
+                config_data = ConfigLoader(config_path).config
+                db_handler.upload_config(config_data, config_path)
+
         else:
             db_maintainer = DBMaintenance(db_handler)
             sys.exit(


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
closes #327 

Solution
========
What I/we did to solve this problem
- add functionalities to 
    - upload local config files to firebase 
    - pack a firebase recipe with a firebase config files 
    - have the config loader to read firebase configs 

## Type of change
Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. upload a config to firebase: `upload -c [CONFIG-LOCAL-PATH]`
2. pack a firebase recipe with a firebase config files: `pack -r [RECIPE-FIREBASE-PATH] -c [CONFIG-FIREBASE-PATH]`

Note: To locate the correct firebase path, navigate to firebase database, look for `config_path` field in config files and `recipe_path` field in recipe files. Use the values of these fields in your command.
