### PR TITLE
Fix: default db for packing remote configs

### DIFF
--- a/cellpack/autopack/__init__.py
+++ b/cellpack/autopack/__init__.py
@@ -398,7 +398,7 @@ def load_file(
     if is_remote_path(filename):
         database_name, file_path = convert_db_shortname_to_url(filename)
         db = DATABASE_IDS.handlers().get(database_name)
-        initialize_db = db()
+        initialize_db = db(default_db="staging") if use_docker else db()
 
         if not initialize_db._initialized:
             readme_url = "https://github.com/mesoscope/cellpack?tab=readme-ov-file#introduction-to-remote-databases"

--- a/cellpack/autopack/loaders/config_loader.py
+++ b/cellpack/autopack/loaders/config_loader.py
@@ -52,7 +52,7 @@ class ConfigLoader(object):
         "version": 1.0,
     }
 
-    def __init__(self, input_file_path=None):
+    def __init__(self, input_file_path=None, use_docker=False):
         if input_file_path is not None:
             _, file_extension = os.path.splitext(input_file_path)
             self.file_path = input_file_path
@@ -60,7 +60,7 @@ class ConfigLoader(object):
         else:
             self.file_path = None
         self.latest_version = 1.0
-        self.config = self._read()
+        self.config = self._read(use_docker=use_docker)
 
     @staticmethod
     def _test_types(config):
@@ -97,7 +97,7 @@ class ConfigLoader(object):
     def _migrate_version(config):
         return config
 
-    def _read(self):
+    def _read(self, use_docker=False):
         """
         Read in a Json Config file.
         """
@@ -107,7 +107,7 @@ class ConfigLoader(object):
             if autopack.is_remote_path(self.file_path):
                 database_name, _ = self.file_path.split(":")
                 db = DATABASE_IDS.handlers().get(database_name)
-                initialize_db = db()
+                initialize_db = db(default_db="staging") if use_docker else db()
                 db_handler = DBRecipeLoader(initialize_db)
                 config = db_handler.read_config(self.file_path)
             else:

--- a/cellpack/bin/pack.py
+++ b/cellpack/bin/pack.py
@@ -30,7 +30,7 @@ def pack(recipe, config_path=None, analysis_config_path=None, docker=False):
 
     :return: void
     """
-    packing_config_data = ConfigLoader(config_path).config
+    packing_config_data = ConfigLoader(config_path, docker).config
     recipe_data = RecipeLoader(
         recipe, packing_config_data["save_converted_recipe"], docker
     ).recipe_data


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
we need to set the default db to staging when running batch jobs

Solution
========
What I/we did to solve this problem
- similar to how we did to recipe, added default db to config file packings
with @alli

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)


Steps to Verify:
----------------
1. upload a config to firebase: upload -c [CONFIG-LOCAL-PATH] to `staging`
2. pack a firebase recipe with a firebase config files: pack -r [RECIPE-FIREBASE-PATH] -c [CONFIG-FIREBASE-PATH] -d
3. verify if it uses `staging` db

