### PR TITLE
Bug Fix: keep grid_file_path when loading recipe from firebase

### DIFF
--- a/cellpack/autopack/DBRecipeHandler.py
+++ b/cellpack/autopack/DBRecipeHandler.py
@@ -695,7 +695,7 @@ class DBRecipeLoader(object):
         recipe_data = {
             **{
                 k: db_recipe_data[k]
-                for k in ["format_version", "version", "name", "bounding_box"]
+                for k in ["format_version", "version", "name", "bounding_box", "grid_file_path"]
             },
             "objects": DBRecipeLoader.remove_dedup_hash(obj_dict),
             "composition": DBRecipeLoader.remove_dedup_hash(comp_dict),


### PR DESCRIPTION
Problem
=======
When testing the cellpack client with a provided grid_file_path, we noticed it wasn't actually getting applied. The reason was when recipes are loaded from cellpack, the grid_file_path was getting dropped when the recipe was getting processed, so it was never brought into the packing step.

Solution
========
Add `grid_file_path` as one of the top level keys we want to keep

## Type of change
* Bug fix (non-breaking change which fixes an issue)
