### PR TITLE
Fix deploy to github pages

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - fix/deploy-action
   workflow_dispatch:
 
 # Grant GITHUB_TOKEN the permissions required to make a Pages deployment


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
The `deploy` job in `Documentation` github action is currently failing. 
`Error: No artifacts named "github-pages" were found for this workflow run. Ensure artifacts are uploaded with actions/upload-artifact@v4 or later.`

Solution
========
What I/we did to solve this problem
- added `id:deployment` to the `Upload artifact` step so the deploy job receives the expected step output.

Notes for future reference: 
The `actions/deploy-pages@v4` ([doc](https://github.com/actions/upload-artifact/pkgs/container/upload-artifact/285342229?tag=4.4.1)) action doesn't just look for any artifact named `github-pages`, it looks for metadata about the artifact that gets passed between jobs. We decided to keep using `actions/upload-pages-artifact@v3` ([repo](https://github.com/actions/upload-pages-artifact)) for now because it's optimized for github pages deployments and it's actively maintained. 

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)


Steps to Verify:
----------------
1. the workflow builds and deploys: https://github.com/mesoscope/cellpack/actions/runs/17145485160
2. should be work the same after merging to main


