### PR TITLE
Updates to make python 3.11 work for our ECS Docker image

### DIFF
--- a/cellpack/autopack/__init__.py
+++ b/cellpack/autopack/__init__.py
@@ -177,8 +177,8 @@ REPLACE_PATH = {
     "autoPACKserver": autoPACKserver,
     "autopackdir": autopackdir,
     "autopackdata": appdata,
-    DATABASE_IDS.GITHUB + ":": autoPACKserver,
-    DATABASE_IDS.FIREBASE + ":": None,
+    f"{DATABASE_IDS.GITHUB.value}:": autoPACKserver,
+    f"{DATABASE_IDS.FIREBASE.value}:": None,
 }
 
 

--- a/cellpack/autopack/__init__.py
+++ b/cellpack/autopack/__init__.py
@@ -177,8 +177,8 @@ REPLACE_PATH = {
     "autoPACKserver": autoPACKserver,
     "autopackdir": autopackdir,
     "autopackdata": appdata,
-    f"{DATABASE_IDS.GITHUB}:": autoPACKserver,
-    f"{DATABASE_IDS.FIREBASE}:": None,
+    DATABASE_IDS.GITHUB + ":": autoPACKserver,
+    DATABASE_IDS.FIREBASE + ":": None,
 }
 
 

--- a/docker/Dockerfile.ecs
+++ b/docker/Dockerfile.ecs
@@ -1,12 +1,11 @@
-FROM python:3.9
+FROM python:3.11
 
 WORKDIR /cellpack
+COPY . /cellpack
 
 RUN python -m pip install --upgrade pip --root-user-action=ignore
-RUN pip install cellpack@git+https://github.com/mesoscope/cellpack.git
+RUN python -m pip install . -r requirements/linux/requirements.txt --root-user-action=ignore
 
-COPY docker/server.py /cellpack/
-COPY .env /cellpack/
 EXPOSE 80
 
 RUN apt-get update && apt-get install -y awscli

--- a/docker/entrypoint-ecs.sh
+++ b/docker/entrypoint-ecs.sh
@@ -5,4 +5,4 @@ if [ -z "$local" ]; then
 fi
 
 cd /cellpack
-python server.py
+python docker/server.py

--- a/docker/server.py
+++ b/docker/server.py
@@ -64,7 +64,7 @@ async def init_app() -> web.Application:
     app.add_routes(
         [
             web.get("/hello", server.hello_world),
-            web.post("/pack", server.pack_handler),
+            web.post("/start-packing", server.pack_handler),
             web.get("/", server.health_check)
         ]
     )


### PR DESCRIPTION
It's time to deploy a new docker image to ECS with python 3.11, since that's what cellpack uses now.

Ran into a couple bugs along the way, some of which were not related to the upgrade, and fixing them all here. 

The Docker image generated by this updated Dockerfile has already been uploaded to ECR and is currently being used in out ECS instance!
