### PR TITLE
Update deepdiff to version 8.6.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ requires-python = "~=3.11.0"
 dependencies = [
     "aicsimageio",
     "boto3",
-    "deepdiff",
+    "deepdiff>=8.6.1",
     "fire",
     "firebase-admin",
     "grpcio",

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
-revision = 2
-requires-python = ">=3.11.0, <3.12"
+revision = 3
+requires-python = "==3.11.*"
 resolution-markers = [
     "sys_platform != 'emscripten'",
     "sys_platform == 'emscripten'",
@@ -305,7 +305,7 @@ test = [
 requires-dist = [
     { name = "aicsimageio" },
     { name = "boto3" },
-    { name = "deepdiff" },
+    { name = "deepdiff", specifier = ">=8.6.1" },
     { name = "fire" },
     { name = "firebase-admin" },
     { name = "grpcio" },
@@ -603,14 +603,14 @@ wheels = [
 
 [[package]]
 name = "deepdiff"
-version = "8.6.0"
+version = "8.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "orderly-set" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/03/65/57d5047a03700ccb3eaab9d86837168701b1527fdd2bd9fe7a212bee83b1/deepdiff-8.6.0.tar.gz", hash = "sha256:6197216c2d777c3106a9989055c230e25848e599b26dcbcdc66226bd8d7fe901", size = 631801, upload-time = "2025-08-08T19:00:27.563Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/76/36c9aab3d5c19a94091f7c6c6e784efca50d87b124bf026c36e94719f33c/deepdiff-8.6.1.tar.gz", hash = "sha256:ec56d7a769ca80891b5200ec7bd41eec300ced91ebcc7797b41eb2b3f3ff643a", size = 634054, upload-time = "2025-09-03T19:40:41.461Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/4d/4c9ba906175430d6f1cb40b7aa90673720c2c4b3fcea03a3719b1906f983/deepdiff-8.6.0-py3-none-any.whl", hash = "sha256:db80677a434ac1f84147fd1598e93f1beb06d467e107af45fcf77cf8a681169f", size = 91121, upload-time = "2025-08-08T19:00:25.575Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/e6/efe534ef0952b531b630780e19cabd416e2032697019d5295defc6ef9bd9/deepdiff-8.6.1-py3-none-any.whl", hash = "sha256:ee8708a7f7d37fb273a541fa24ad010ed484192cd0c4ffc0fa0ed5e2d4b9e78b", size = 91378, upload-time = "2025-09-03T19:40:39.679Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Problem
<!-- What is the problem this work solves, including -->
<!-- [Link to story or ticket](https://my-tracking-system.url/ticket-number) -->
Fixes [security vulnerability](https://github.com/mesoscope/cellpack/security/dependabot/66) in deepdiff. 
# Solution
<!-- What I/we did to solve this problem -->
Updated deepdiff to version `8.6.1`
<!-- with @pairperson1 -->

## Type of change
<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

## Change summary:

<!-- * Tidy, well formulated commit message -->
<!-- * Another great commit message -->
<!-- * Something else I/we did -->
Add new deepdiff version to `pyproject.toml` and update `uv.lock`

## Steps to Verify:
<!-- 1. A setup step / beginning state -->
<!-- 1. What to do next -->
<!-- 1. Any other instructions -->
<!-- 1. Expected behavior -->
<!-- 1. Suggestions for testing -->
Please verify if deepdiff related operations still work after this update
