### PR TITLE
Update validation for gradient decay length

### DIFF
--- a/cellpack/autopack/validation/recipe_models.py
+++ b/cellpack/autopack/validation/recipe_models.py
@@ -1,6 +1,7 @@
-from pydantic import BaseModel, Field, field_validator, model_validator
-from typing import Optional, List, Dict, Any, Union
 from enum import Enum
+from typing import Any, Dict, List, Optional, Union
+
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 # note: ge(>=), le(<=), gt(>), lt(<)
 
@@ -69,7 +70,7 @@ ThreeFloatArray = List[float]
 
 
 class WeightModeSettings(BaseModel):
-    decay_length: Optional[float] = Field(None, ge=0, le=1)
+    exponent_factor: Optional[float] = Field(None, gt=0)
     power: Optional[float] = Field(None, gt=0)
 
 


### PR DESCRIPTION
# Problem
<!-- What is the problem this work solves, including -->
<!-- [Link to story or ticket](https://my-tracking-system.url/ticket-number) -->
For the exponential weighted gradient, the decay length was limited between 0 and 1 (by the validator), but we want to allow weaker gradients by removing the limit of 1.

# Solution
<!-- What I/we did to solve this problem -->
Allow gradient decay length to be any value > 0

<!-- with @pairperson1 -->

## Type of change
<!-- Please delete options that are not relevant. -->
* New feature (non-breaking change which adds functionality)


## Change summary:

Change the recipe validator model to remove upper limit on gradient decay length

## Steps to Verify:
<!-- 1. A setup step / beginning state -->
<!-- 1. What to do next -->
<!-- 1. Any other instructions -->
<!-- 1. Expected behavior -->
<!-- 1. Suggestions for testing -->
Pack any recipe with a gradient, should work as expected
