### PR TITLE
validate recipes during load

### DIFF
--- a/cellpack/autopack/loaders/migrate_v1_to_v2.py
+++ b/cellpack/autopack/loaders/migrate_v1_to_v2.py
@@ -63,16 +63,34 @@ def get_representations(old_ingredient):
 
 
 def convert_rotation_range(old_ingredient):
-    range_min = (
-        old_ingredient["orientBiasRotRangeMin"]
-        if "orientBiasRotRangeMin" in old_ingredient
-        else -pi
-    )
-    range_max = (
-        old_ingredient["orientBiasRotRangeMax"]
-        if "orientBiasRotRangeMax" in old_ingredient
-        else pi
-    )
+    has_min = "orientBiasRotRangeMin" in old_ingredient
+    has_max = "orientBiasRotRangeMax" in old_ingredient
+
+    if has_min and has_max:
+        range_min = old_ingredient["orientBiasRotRangeMin"]
+        range_max = old_ingredient["orientBiasRotRangeMax"]
+        if range_min > range_max:
+            range_min, range_max = range_max, range_min
+    elif has_min and not has_max:
+        provided_min = old_ingredient["orientBiasRotRangeMin"]
+        if provided_min > pi:
+            range_min = -pi
+            range_max = provided_min
+        else:
+            range_min = provided_min
+            range_max = pi
+    elif has_max and not has_min:
+        provided_max = old_ingredient["orientBiasRotRangeMax"]
+        if provided_max < -pi:
+            range_min = provided_max
+            range_max = pi
+        else:
+            range_min = -pi
+            range_max = provided_max
+    else:
+        range_min = -pi
+        range_max = pi
+
     return [range_min, range_max]
 
 

--- a/cellpack/autopack/loaders/recipe_loader.py
+++ b/cellpack/autopack/loaders/recipe_loader.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
 import copy
 import json
+import logging
 import os
 from json import encoder
 
 import cellpack.autopack as autopack
+
+log = logging.getLogger(__name__)
 from cellpack.autopack.DBRecipeHandler import DBRecipeLoader
 from cellpack.autopack.interface_objects import (
     GradientData,
@@ -183,15 +186,6 @@ class RecipeLoader(object):
                 new_values, objects, gradients, composition
             )
 
-            # validate the converted firebase recipe
-            try:
-                RecipeValidator.validate_recipe(new_values)
-            except ValidationError as e:
-                formatted_error = RecipeValidator.format_validation_error(e)
-                raise ValueError(
-                    f"Firebase recipe validation failed:\n{formatted_error}"
-                )
-
         recipe_data = RecipeLoader.default_values.copy()
         recipe_data = deep_merge(recipe_data, new_values)
         recipe_data["format_version"] = RecipeLoader._sanitize_format_version(
@@ -206,6 +200,15 @@ class RecipeLoader(object):
                 recipe_data["objects"] = RecipeLoader.resolve_inheritance(
                     recipe_data["objects"]
                 )
+        # validate recipe after migration to v2.1 format but before transforming to class instances
+        try:
+            RecipeValidator.validate_recipe(recipe_data)
+            log.info("Recipe validation passed")
+        except ValidationError as e:
+            formatted_error = RecipeValidator.format_validation_error(e)
+            raise ValueError(f"Recipe validation failed:\n{formatted_error}")
+
+        if "objects" in recipe_data:
             for _, obj in recipe_data["objects"].items():
                 reps = obj["representations"] if "representations" in obj else {}
                 obj["representations"] = Representations(

--- a/cellpack/bin/pack.py
+++ b/cellpack/bin/pack.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import logging.config
 import os
@@ -6,7 +5,6 @@ import time
 from pathlib import Path
 
 import fire
-from pydantic import ValidationError
 
 from cellpack import autopack
 from cellpack.autopack import upy
@@ -18,7 +16,6 @@ from cellpack.autopack.IOutils import format_time
 from cellpack.autopack.loaders.analysis_config_loader import AnalysisConfigLoader
 from cellpack.autopack.loaders.config_loader import ConfigLoader
 from cellpack.autopack.loaders.recipe_loader import RecipeLoader
-from cellpack.autopack.validation.recipe_validator import RecipeValidator
 
 ###############################################################################
 log_file_path = Path(__file__).parent.parent / "logging.conf"
@@ -41,19 +38,6 @@ def pack(
     :return: void
     """
     packing_config_data = ConfigLoader(config_path, docker).config
-
-    # validate local recipes before packing
-    # firebase recipes are validated automatically in RecipeLoader._read()
-    if validate and not recipe.startswith("firebase:"):
-        try:
-            with open(recipe, "r") as f:
-                raw_recipe_data = json.load(f)
-            RecipeValidator.validate_recipe(raw_recipe_data)
-            log.info("Local recipe validation passed!")
-        except ValidationError as e:
-            formatted_error = RecipeValidator.format_validation_error(e)
-            log.error(formatted_error)
-            return
 
     recipe_data = RecipeLoader(
         recipe, packing_config_data["save_converted_recipe"], docker

--- a/cellpack/bin/validate.py
+++ b/cellpack/bin/validate.py
@@ -1,11 +1,8 @@
 import logging
 import logging.config
 import fire
-import json
 from pathlib import Path
-from pydantic import ValidationError
 
-from cellpack.autopack.validation.recipe_validator import RecipeValidator
 from cellpack.autopack.loaders.recipe_loader import RecipeLoader
 
 ###############################################################################
@@ -17,21 +14,11 @@ log = logging.getLogger()
 
 def validate(recipe_path):
     try:
-        if recipe_path.startswith("firebase:"):
-            loader = RecipeLoader(recipe_path, use_docker=True)
-            recipe_data = loader.recipe_data
-            log.info(f"Firebase recipe {recipe_data['name']} is valid!")
-        else:
-            with open(recipe_path, "r") as f:
-                raw_recipe_data = json.load(f)
+        use_docker = recipe_path.startswith("firebase:")
+        loader = RecipeLoader(recipe_path, use_docker=use_docker)
+        recipe_data = loader.recipe_data
+        log.info(f"Recipe {recipe_data['name']} is valid!")
 
-            RecipeValidator.validate_recipe(raw_recipe_data)
-            log.info(f"Local recipe {raw_recipe_data['name']} is valid!")
-
-    except ValidationError as e:
-        formatted_error = RecipeValidator.format_validation_error(e)
-        log.error(formatted_error)
-        return
     except ValueError as e:
         log.error(str(e))
         return

--- a/cellpack/tests/test_recipe_version_migration.py
+++ b/cellpack/tests/test_recipe_version_migration.py
@@ -161,7 +161,7 @@ def test_create_packing_atomic_representation(
             },
             {
                 "count": 15,
-                "orient_bias_range": [6, pi],
+                "orient_bias_range": [-pi, 6],
                 "representations": RecipeLoader.default_values["representations"],
                 "type": INGREDIENT_TYPE.GROW,
             },
@@ -271,7 +271,7 @@ def test_get_v1_ingredient():
                     "radius": 10,
                     "packing_mode": "random",
                     "representations": RecipeLoader.default_values["representations"],
-                    "orient_bias_range": [6, pi],
+                    "orient_bias_range": [-pi, 6],
                 },
                 "C": {
                     "orient_bias_range": [-pi, 12],
@@ -332,7 +332,7 @@ def test_convert_v1_to_v2(
                         "type": INGREDIENT_TYPE.SINGLE_SPHERE,
                     },
                     "B": {
-                        "orient_bias_range": [6, pi],
+                        "orient_bias_range": [-pi, 6],
                         "packing_mode": "random",
                         "radius": 40,
                         "representations": Representations(


### PR DESCRIPTION
# Problem
<!-- What is the problem this work solves, including -->
closes #401 

# Solution
<!-- What I/we did to solve this problem -->
- move validation to `RecipeLoader._read()` after data migration
    - fixed validation error when packing v1 recipes
    - consolidated validation to one spot that works for all recipes (v1/v2/firebase)
- Simplify `validate.py` to use RecipeLoader for all recipe
- improved data migration tests for `orientBiasRotRange`

## Type of change
<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)
* Refactor (non-breaking change which adds functionality)

## Steps to Verify:
1. run validate [ANY-VALID-RECIPE-PATH]
    - v1 `validate examples/recipes/v1/one_sphere.json`
    - v2 `validate examples/recipes/v2/pcna_surface_gradient.json`
    - firebase `validate firebase:recipes/gradients_v_default -d `
2. run pack -r [ANY-VALID-RECIPE-PATH]

