### PR TITLE
Quick fix: add randomness_seed to upload and download

### DIFF
--- a/cellpack/autopack/DBRecipeHandler.py
+++ b/cellpack/autopack/DBRecipeHandler.py
@@ -853,6 +853,8 @@ class DBRecipeLoader(object):
         }
         if db_recipe_data.get("grid_file_path"):
             recipe_data["grid_file_path"] = db_recipe_data.get("grid_file_path")
+        if db_recipe_data.get("randomness_seed"):
+            recipe_data["randomness_seed"] = db_recipe_data.get("randomness_seed")
         if grad_dict:
             recipe_data["gradients"] = [
                 {**v} for v in DBRecipeLoader.remove_dedup_hash(grad_dict).values()

--- a/cellpack/bin/upload.py
+++ b/cellpack/bin/upload.py
@@ -23,6 +23,8 @@ def get_recipe_metadata(loader):
         }
         if "grid_file_path" in loader.recipe_data:
             recipe_meta_data["grid_file_path"] = loader.recipe_data["grid_file_path"]
+        if "randomness_seed" in loader.recipe_data:
+            recipe_meta_data["randomness_seed"] = loader.recipe_data["randomness_seed"]
         return recipe_meta_data
     except KeyError as e:
         sys.exit(f"Recipe metadata is missing. {e}")


### PR DESCRIPTION
# Problem
<!-- What is the problem this work solves, including -->
Just realized `randomness_seed` has been excluded from the upload and download pipeline

# Solution
<!-- What I/we did to solve this problem -->
- added `randomness_seed` to top level data when applicable
- checked all current recipes, `randomness_seed` was the only field being dropped 


potential todo: preserving all top-level recipe metadata dynamically instead of hardcoding field extraction


## Type of change
<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)


## Steps to Verify:
1. upload a recipe containing `randomness_seed` to your **DEV** database for testing 
2. or refer to the attached the screenshot below
<img width="995" height="523" alt="Screenshot 2025-10-22 at 12 14 02 PM" src="https://github.com/user-attachments/assets/3c859040-cfeb-4bc0-97bb-245925703649" />