### PR TITLE
fix workflow: run `iterative/setup-cml@v2 ` with `vega` disabled

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -58,7 +58,7 @@ jobs:
               run: aws s3 cp ./results s3://cellpack-results/${{  github.ref_name  }}/ --recursive --acl public-read
             - uses: iterative/setup-cml@v2
               with:
-                vega: false # we only use CML to post markdown reports, so disable vega to to skip extra npm installs   
+                vega: false # we only use CML to post markdown reports, so disable vega to skip extra npm installs
             - name: Update comment for dependabot
               if: ${{ github.actor == 'dependabot[bot]' }}
               env:


### PR DESCRIPTION
# Problem
<!-- What is the problem this work solves, including -->
one of the github action jobs is start failing globally. [error log](https://github.com/mesoscope/cellpack/actions/runs/18788266453/job/53612304072)
```
Run iterative/setup-cml@v2
/usr/local/bin/npm install --global canvas@2 vega@5 vega-cli@5 vega-lite@5
npm error code ETARGET
npm error notarget No matching version found for vega-util@^1.17.4.
npm error notarget In most cases you or one of your dependencies are requesting
npm error notarget a package version that doesn't exist.
npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2025-10-24T18_15_44_619Z-debug-0.log
/home/runner/work/_actions/iterative/setup-cml/v2/dist/index.js:2348
                error = new Error(`The process '${this.toolPath}' failed with exit code ${this.processExitCode}`);
                        ^

Error: The process '/usr/local/bin/npm' failed with exit code 1
    at ExecState._setResult (/home/runner/work/_actions/iterative/setup-cml/v2/dist/index.js:2348:25)
    at ExecState.CheckComplete (/home/runner/work/_actions/iterative/setup-cml/v2/dist/index.js:2331:18)
    at ChildProcess.<anonymous> (/home/runner/work/_actions/iterative/setup-cml/v2/dist/index.js:2225:27)
    at ChildProcess.emit (node:events:524:28)
    at maybeClose (node:internal/child_process:1104:16)
    at ChildProcess._handle.onexit (node:internal/child_process:304:5)

Node.js v20.19.5
```

The failure occurred because npm install tries to fetch `vega-util@^1.17.4`, which was recently unpublished from the npm registry.

# Solution
<!-- What I/we did to solve this problem -->
- disable vega installation by setting `vega: false` in the `setup-cml` step. this skips the npm dependency install step and prevents ci from breaking between version changes

more context:
vega is a javascript visualization library used by `cml` to generate charts and plots for metrics reporting. our workflow only uses cml to post markdown reports to pull requests and does not rely on any vega-based chart generation, so disabling it has no functional impact on the reports. [documentation](https://github.com/iterative/setup-cml)



## Type of change
<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)


## Steps to Verify:
1. the job step using `iterative/setup-cml@v2` should pass for all open pull requests

