### PR TITLE
pr commenting: use native github CLI

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -4,7 +4,6 @@ on:
     push:
         branches:
             - main
-            - feature/github-cli
     pull_request:
 
 jobs:


### PR DESCRIPTION
# Problem
<!-- What is the problem this work solves, including -->
closes #422 
documentation: https://cli.github.com/manual/gh_pr_comment

# Solution
<!-- What I/we did to solve this problem -->
- removed `iterative/setup-cml@v2`
- updated both comment steps to use native gh cli commands 
    - now uses an html comment marker to identify workflow-generated comments 
- added logic: detect and delete if an existing comment found, post a fresh comment containing the latest report



## Type of change
<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)


## Steps to Verify:
1. everything in the `Comment` job should behave the same as before
2. verify the comment is correctly post, updated, and only one exists at a time in this pr