### PR TITLE
Fix `Comment` job failing on `main` pushes 

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -57,7 +57,7 @@ jobs:
             - name: Copy files to results bucket
               run: aws s3 cp ./results s3://cellpack-results/${{  github.ref_name  }}/ --recursive --acl public-read
             - name: Update comment for dependabot
-              if: ${{ github.actor == 'dependabot[bot]' }}
+              if: ${{ github.event_name == 'pull_request' && github.actor == 'dependabot[bot]' }}
               env:
                   GH_TOKEN: ${{ secrets.DEPENDABOT_TOKEN }}
               run: |
@@ -70,7 +70,7 @@ jobs:
                   echo -e "$COMMENT_BODY" | gh pr comment ${{ github.event.pull_request.number }} --body-file -
                   cat ./results/analysis_report.md
             - name: Update comment for PR
-              if: ${{ github.actor != 'dependabot[bot]' }}
+              if: ${{ github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' }}
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |


### PR DESCRIPTION
# Problem
<!-- What is the problem this work solves, including -->
#422 merged but broke the `Comment` job on `main`
The `iterative/setup-cml` action quietly skipped commenting when running on a push to main, but the raw gh commands assume a pull request always exists. 

# Solution
<!-- What I/we did to solve this problem -->
- Added check guards so the `Comment` job only runs when there is a pull request


## Type of change
<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)
