### PR TITLE
Fix Comment Update job: use gh api instead of gh pr review

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -78,7 +78,8 @@ jobs:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
                   MARKER="<!-- Analyze workflow report -->"
-                  COMMENT_BODY="${MARKER}\n$(cat ./results/analysis_report.md)"
+                  COMMENT_BODY="${MARKER}
+                  $(cat ./results/analysis_report.md)"
                   EXISTING_COMMENT_ID=$(gh api "/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" --jq ".[] | select(.body | contains(\"${MARKER}\")) | .id" | head -1)
                   if [ -n "$EXISTING_COMMENT_ID" ]; then
                     echo "Updating existing comment with ID: $EXISTING_COMMENT_ID"


### PR DESCRIPTION
# Problem
<!-- What is the problem this work solves, including -->
closes #422 

a new bug was introduced in the last fix: 
when new commits are pushed to an open pr, the workflow fails to delete the existing analysis report, causing duplicated comments in one pull request 

# Solution
<!-- What I/we did to solve this problem -->
- replaced `gh pr view` with `gh api` to make sure the return id format is compatible with REST API
- switched from `delete` to `patch` approach to avoid issues like `GITHUB_TOKEN` permissions 

## Type of change
<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

## Steps to Verify:
1. tested by pushing test commits, verify if there is only one analysis report appears in one open pr and all jobs passed

